### PR TITLE
feat: StorageModule with Supabase upload/download/delete

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -27,6 +27,7 @@
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
     "@prisma/client": "^6.19.3",
+    "@supabase/supabase-js": "^2.105.4",
     "prisma": "^6.19.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"

--- a/apps/api/src/storage/storage.constants.ts
+++ b/apps/api/src/storage/storage.constants.ts
@@ -1,0 +1,1 @@
+export const SUPABASE_CLIENT = Symbol('SUPABASE_CLIENT');

--- a/apps/api/src/storage/storage.module.ts
+++ b/apps/api/src/storage/storage.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_CLIENT } from './storage.constants';
+import { StorageService } from './storage.service';
+
+@Module({
+  providers: [
+    {
+      provide: SUPABASE_CLIENT,
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) =>
+        createClient(
+          config.getOrThrow<string>('SUPABASE_URL'),
+          config.getOrThrow<string>('SUPABASE_SERVICE_ROLE_KEY'),
+        ),
+    },
+    StorageService,
+  ],
+  exports: [StorageService],
+})
+export class StorageModule {}

--- a/apps/api/src/storage/storage.service.spec.ts
+++ b/apps/api/src/storage/storage.service.spec.ts
@@ -1,0 +1,94 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InternalServerErrorException } from '@nestjs/common';
+import { StorageService } from './storage.service';
+import { SUPABASE_CLIENT } from './storage.constants';
+
+const mockSupabaseClient = {
+  storage: {
+    from: jest.fn(),
+  },
+};
+
+describe('StorageService', () => {
+  let service: StorageService;
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StorageService,
+        { provide: SUPABASE_CLIENT, useValue: mockSupabaseClient },
+      ],
+    }).compile();
+
+    service = module.get<StorageService>(StorageService);
+  });
+
+  describe('upload', () => {
+    it('should return the file path on success', async () => {
+      mockSupabaseClient.storage.from.mockReturnValue({
+        upload: jest.fn().mockResolvedValue({ data: { path: 'user-1/file.pdf' }, error: null }),
+      });
+
+      const result = await service.upload('invoices', 'user-1/file.pdf', Buffer.from('pdf'), 'application/pdf');
+
+      expect(result).toBe('user-1/file.pdf');
+    });
+
+    it('should throw InternalServerErrorException when Supabase returns an error', async () => {
+      mockSupabaseClient.storage.from.mockReturnValue({
+        upload: jest.fn().mockResolvedValue({ data: null, error: { message: 'bucket not found' } }),
+      });
+
+      await expect(
+        service.upload('invoices', 'user-1/file.pdf', Buffer.from('pdf'), 'application/pdf'),
+      ).rejects.toThrow(InternalServerErrorException);
+    });
+  });
+
+  describe('download', () => {
+    it('should return a Buffer with the file content on success', async () => {
+      const fileContent = Buffer.from('pdf content');
+      mockSupabaseClient.storage.from.mockReturnValue({
+        download: jest.fn().mockResolvedValue({ data: new Blob([fileContent]), error: null }),
+      });
+
+      const result = await service.download('invoices', 'user-1/file.pdf');
+
+      expect(result).toBeInstanceOf(Buffer);
+    });
+
+    it('should throw InternalServerErrorException when Supabase returns an error', async () => {
+      mockSupabaseClient.storage.from.mockReturnValue({
+        download: jest.fn().mockResolvedValue({ data: null, error: { message: 'object not found' } }),
+      });
+
+      await expect(
+        service.download('invoices', 'user-1/file.pdf'),
+      ).rejects.toThrow(InternalServerErrorException);
+    });
+  });
+
+  describe('delete', () => {
+    it('should resolve without error on success', async () => {
+      mockSupabaseClient.storage.from.mockReturnValue({
+        remove: jest.fn().mockResolvedValue({ data: {}, error: null }),
+      });
+
+      await expect(
+        service.delete('invoices', 'user-1/file.pdf'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('should throw InternalServerErrorException when Supabase returns an error', async () => {
+      mockSupabaseClient.storage.from.mockReturnValue({
+        remove: jest.fn().mockResolvedValue({ data: null, error: { message: 'object not found' } }),
+      });
+
+      await expect(
+        service.delete('invoices', 'user-1/file.pdf'),
+      ).rejects.toThrow(InternalServerErrorException);
+    });
+  });
+});

--- a/apps/api/src/storage/storage.service.ts
+++ b/apps/api/src/storage/storage.service.ts
@@ -1,0 +1,43 @@
+import { Inject, Injectable, InternalServerErrorException } from '@nestjs/common';
+import { SupabaseClient } from '@supabase/supabase-js';
+import { SUPABASE_CLIENT } from './storage.constants';
+
+@Injectable()
+export class StorageService {
+  constructor(@Inject(SUPABASE_CLIENT) private readonly supabase: SupabaseClient) {}
+
+  async upload(bucket: string, path: string, file: Buffer, mimeType: string): Promise<string> {
+    const { data, error } = await this.supabase.storage.from(bucket).upload(path, file, {
+      contentType: mimeType,
+      upsert: false,
+    });
+
+    if (error || !data) {
+      this.fail('upload', error?.message ?? 'no data returned');
+    }
+
+    return data.path;
+  }
+
+  async download(bucket: string, path: string): Promise<Buffer> {
+    const { data, error } = await this.supabase.storage.from(bucket).download(path);
+
+    if (error || !data) {
+      this.fail('download', error?.message ?? 'no data returned');
+    }
+
+    return Buffer.from(await data.arrayBuffer());
+  }
+
+  async delete(bucket: string, path: string): Promise<void> {
+    const { error } = await this.supabase.storage.from(bucket).remove([path]);
+
+    if (error) {
+      this.fail('delete', error.message);
+    }
+  }
+
+  private fail(op: string, message: string): never {
+    throw new InternalServerErrorException(`Storage ${op} failed: ${message}`);
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@prisma/client':
         specifier: ^6.19.3
         version: 6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3)
+      '@supabase/supabase-js':
+        specifier: ^2.105.4
+        version: 2.105.4
       prisma:
         specifier: ^6.19.3
         version: 6.19.3(typescript@5.9.3)
@@ -1197,6 +1200,33 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@supabase/auth-js@2.105.4':
+    resolution: {integrity: sha512-Ejfa37M5xoIwoxVebxRahnwubPo8g22qkXQ4p50+N9MIvU9UZoN+A8dwVPtczzGf8oV/YXN80ZPxK4aWXuSN/A==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.105.4':
+    resolution: {integrity: sha512-JVNKbBft3Qkja+WlGaE026AJ2AH9K0UTsxsfvEIHgd4zFrBor4BYRCrYFrv9IDsvVqkF72wKDsODJl5GY/C4tA==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/phoenix@0.4.2':
+    resolution: {integrity: sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==}
+
+  '@supabase/postgrest-js@2.105.4':
+    resolution: {integrity: sha512-SppIyLo/kTwIlz1qpv2HN1EQqBg0GVktrDDFsXygYROha3MgVn4rT7p5EjFHFqXQm2rdRGb/BI7bc+jr10m91w==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.105.4':
+    resolution: {integrity: sha512-6ov6c59+8D9h7q4M4Gy/uDJlC0Akxl9/714Y+6vJ+Sijuc16TS/p5DwhfRCLNcIhNiej1gEt+CQUwsjiPt4PxQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/storage-js@2.105.4':
+    resolution: {integrity: sha512-Jx+pzMP1Whjof2PWHoVBUA75/p7PQE9CqKBzn1oXVyJDOggMLSH2OzVWwsXYaxEpdC1K/KltwmOX44nL3LHl9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.105.4':
+    resolution: {integrity: sha512-cEnx+k49knU+qdIP7rXwR6fqEXPHZs+74xFK1R0S8MgQ7v9tbePVdGxvO03n3bPympMdJWVLadARBfU4TgNHCQ==}
+    engines: {node: '>=20.0.0'}
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
@@ -2827,6 +2857,10 @@ packages:
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -5687,6 +5721,38 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@supabase/auth-js@2.105.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.105.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/phoenix@0.4.2': {}
+
+  '@supabase/postgrest-js@2.105.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.105.4':
+    dependencies:
+      '@supabase/phoenix': 0.4.2
+      tslib: 2.8.1
+
+  '@supabase/storage-js@2.105.4':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.105.4':
+    dependencies:
+      '@supabase/auth-js': 2.105.4
+      '@supabase/functions-js': 2.105.4
+      '@supabase/postgrest-js': 2.105.4
+      '@supabase/realtime-js': 2.105.4
+      '@supabase/storage-js': 2.105.4
+
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.15':
@@ -7518,6 +7584,8 @@ snapshots:
       - supports-color
 
   human-signals@2.1.0: {}
+
+  iceberg-js@0.8.1: {}
 
   iconv-lite@0.6.3:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds `StorageModule` with `StorageService` encapsulating Supabase Storage operations: `upload`, `download`, `delete`
- Supabase client injected via `Symbol` token (`SUPABASE_CLIENT`) — mockable in tests, consistent with `AuthModule` pattern
- Errors from Supabase captured and re-thrown as `InternalServerErrorException` via private `fail()` helper
- `StorageModule` exports `StorageService` for explicit import by `InvoicesModule` (issue #13)

## Test plan

- [x] 6 unit tests covering success and error paths for all three operations
- [x] All 17 API tests passing
- [x] All 11 web tests passing

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)