### PR TITLE
feat: configure authorizedParties for Clerk JWT verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,104 @@
 # Luppa
 
-Personal finance SaaS focused on credit card spending analysis. Users upload monthly invoice PDFs and the system automatically extracts, categorizes, and visualizes their expenses — no manual transaction input required.
-
-## How it works
-
-1. User uploads a credit card invoice PDF
-2. The system extracts all transactions from the PDF
-3. Transactions are categorized via LLM + a learned merchant mapping table
-4. Spending is presented as analytics broken down by category
+SaaS de controle financeiro pessoal. Usuários fazem upload de PDFs de fatura de cartão de crédito, o sistema extrai as transações via Claude, categoriza automaticamente e apresenta analytics de gastos.
 
 ## Stack
 
-| Layer | Technology | Reason |
-|---|---|---|
-| Backend | NestJS + TypeScript | See [RFC 001](docs/rfcs/001-stack.md) |
-| Frontend | Next.js 15 + TypeScript | — |
-| Database | PostgreSQL | — |
-| LLM | Anthropic Claude API | — |
-| Infra | Railway + Vercel + Supabase | Low cost to start |
+| Camada | Tecnologia |
+|--------|-----------|
+| Backend | NestJS + TypeScript (Railway) |
+| Frontend | Next.js 15 + TypeScript (Vercel) |
+| Banco | PostgreSQL (Supabase) |
+| Storage | Supabase Storage |
+| Auth | Clerk |
+| LLM | Anthropic Claude API |
 
-## Project structure
+---
 
-```
-apps/
-  api/          → NestJS backend (port 3333)
-  web/          → Next.js frontend (port 3000)
-packages/
-  types/        → Shared TypeScript types
-docs/
-  rfcs/         → Architecture decision records
-```
+## Pré-requisitos
 
-## Setup
+- Node.js 22+
+- pnpm 10+
+- Acesso aos serviços externos (ver seção de acessos abaixo)
 
-**Requirements:** Node.js 20+, pnpm 10+
+---
+
+## Acessos necessários
+
+Peça ao responsável do projeto acesso a:
+
+| Serviço | O que você precisa |
+|---------|-------------------|
+| **Supabase** | Convite para o projeto — você obtém `DATABASE_URL`, `DIRECT_URL`, `SUPABASE_URL` e `SUPABASE_SERVICE_ROLE_KEY` em Settings → API |
+| **Clerk** | Convite para o app — você obtém `CLERK_SECRET_KEY` e `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` em API Keys |
+| **Anthropic** | Acesso à API — você obtém `ANTHROPIC_API_KEY` em console.anthropic.com |
+| **GitHub** | Acesso ao repositório `luppa-financas/app` |
+
+---
+
+## Setup inicial
 
 ```bash
-git clone https://github.com/luppa-app/app
+git clone git@github.com:luppa-financas/app.git
 cd app
 pnpm install
 ```
 
-**Environment variables:**
+### Variáveis de ambiente — API
 
 ```bash
 cp apps/api/.env.example apps/api/.env
 ```
 
-## Running locally
+Edite `apps/api/.env` com os valores reais:
 
-### Full stack (two terminals)
+```env
+NODE_ENV=development
+PORT=3333
+
+# Clerk — dashboard.clerk.com → API Keys
+CLERK_SECRET_KEY=sk_test_...
+CLERK_AUTHORIZED_PARTIES=http://localhost:3000
+
+# Supabase — Settings → API
+DATABASE_URL=postgresql://postgres.[ref]:[password]@aws-0-[region].pooler.supabase.com:6543/postgres?pgbouncer=true
+DIRECT_URL=postgresql://postgres.[ref]:[password]@aws-0-[region].pooler.supabase.com:5432/postgres
+SUPABASE_URL=https://[ref].supabase.co
+SUPABASE_SERVICE_ROLE_KEY=eyJ...
+
+# Anthropic — console.anthropic.com → API Keys
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+### Variáveis de ambiente — Web
+
+```bash
+cp apps/web/.env.example apps/web/.env.local
+```
+
+Edite `apps/web/.env.local` com os valores reais:
+
+```env
+# Clerk — dashboard.clerk.com → API Keys
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_...
+CLERK_SECRET_KEY=sk_test_...
+
+NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
+NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
+
+NEXT_PUBLIC_MAINTENANCE_MODE=false
+```
+
+### Banco de dados
+
+```bash
+# Aplica as migrations no banco
+make migrate-deploy
+```
+
+---
+
+## Rodando localmente
 
 ```bash
 # Terminal 1 — API (http://localhost:3333)
@@ -59,44 +108,74 @@ make dev-api
 make dev-web
 ```
 
-### API only
+Verifique que a API está saudável:
 
 ```bash
-make dev-api
-# or
-cd apps/api && pnpm start:dev
+make health
+# { "status": "OK" }
 ```
 
-### Web only
+---
+
+## Comandos úteis
 
 ```bash
-make dev-web
-# or
-cd apps/web && pnpm dev
+make dev-api        # API em modo watch (porta 3333)
+make dev-web        # Web em modo watch (porta 3000)
+make test           # todos os testes (API + web)
+make build          # build de todos os apps
+make health         # health check da API
+make migrate-deploy # aplica migrations (banco já existente)
+make migrate-dev    # cria nova migration (desenvolvimento)
+make studio         # Prisma Studio (GUI do banco)
 ```
 
-### Via Docker
+---
 
-```bash
-docker-compose up
-# API available at http://localhost:3333
+## Estrutura do projeto
+
+```
+apps/
+  api/          → NestJS backend
+    src/
+      auth/         → AuthGuard + @CurrentUser() + Clerk JWT
+      health/       → GET /health
+      invoices/     → POST /invoices (upload de fatura)
+      storage/      → Supabase Storage (upload/download)
+      prisma/       → PrismaService global
+    prisma/
+      schema.prisma → schema do banco
+    test/           → testes e2e
+  web/          → Next.js frontend
+packages/
+  types/        → tipos TypeScript compartilhados (@luppa/types)
+docs/
+  rfcs/         → decisões de arquitetura
 ```
 
-## Useful commands
+---
 
-```bash
-make build    # build all apps
-make test     # run all tests
-make health   # check API health (requires API running)
-make migrate  # run database migrations
-```
+## Supabase Storage
 
-## Health check
+O bucket `invoices` precisa existir no Supabase Storage com visibilidade **private**.
 
-```bash
-curl http://localhost:3333/health
-# { "status": "ok" }
-```
+Para criar: Supabase Dashboard → Storage → New bucket → nome: `invoices` → Private.
 
-> Invoice PDFs contain personal financial data. Never commit them to git.
-> The `apps/api/src/extraction/testdata/` directory is gitignored for this reason.
+---
+
+## Dados sensíveis
+
+PDFs de fatura contêm dados financeiros pessoais. A pasta `apps/api/src/extraction/testdata/` está no `.gitignore` — use-a para testes locais com faturas reais e nunca faça commit desses arquivos.
+
+---
+
+## Arquitetura
+
+Veja os documentos de decisão em `docs/rfcs/`:
+
+- [RFC 001](docs/rfcs/001-stack.md) — Stack e infraestrutura
+- [RFC 002](docs/rfcs/002-invoice-extraction.md) — Extração de transações via LLM
+- [RFC 003](docs/rfcs/003-categorization.md) — Categorização de transações
+- [RFC 004](docs/rfcs/004-channel-architecture.md) — Arquitetura de canais (web + WhatsApp futuro)
+- [RFC 005](docs/rfcs/005-infra.md) — Decisões de infra
+- [RFC 006](docs/rfcs/006-multitenancy.md) — Multi-tenancy

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -2,6 +2,11 @@
 NODE_ENV=development
 PORT=3333
 
+# Auth (Clerk)
+CLERK_SECRET_KEY=sk_test_...
+# Comma-separated list of allowed frontend origins
+CLERK_AUTHORIZED_PARTIES=http://localhost:3000
+
 # Database (Supabase PostgreSQL)
 # Transaction pooler — used by the app at runtime (port 6543)
 DATABASE_URL=postgresql://postgres.[project-ref]:[password]@aws-0-[region].pooler.supabase.com:6543/postgres?pgbouncer=true

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,98 +1,16 @@
-<p align="center">
-  <a href="http://nestjs.com/" target="blank"><img src="https://nestjs.com/img/logo-small.svg" width="120" alt="Nest Logo" /></a>
-</p>
+# Luppa API
 
-[circleci-image]: https://img.shields.io/circleci/build/github/nestjs/nest/master?token=abc123def456
-[circleci-url]: https://circleci.com/gh/nestjs/nest
+Backend NestJS do Luppa. Para setup completo veja o [README raiz](../../README.md).
 
-  <p align="center">A progressive <a href="http://nodejs.org" target="_blank">Node.js</a> framework for building efficient and scalable server-side applications.</p>
-    <p align="center">
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/v/@nestjs/core.svg" alt="NPM Version" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/l/@nestjs/core.svg" alt="Package License" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/dm/@nestjs/common.svg" alt="NPM Downloads" /></a>
-<a href="https://circleci.com/gh/nestjs/nest" target="_blank"><img src="https://img.shields.io/circleci/build/github/nestjs/nest/master" alt="CircleCI" /></a>
-<a href="https://discord.gg/G7Qnnhy" target="_blank"><img src="https://img.shields.io/badge/discord-online-brightgreen.svg" alt="Discord"/></a>
-<a href="https://opencollective.com/nest#backer" target="_blank"><img src="https://opencollective.com/nest/backers/badge.svg" alt="Backers on Open Collective" /></a>
-<a href="https://opencollective.com/nest#sponsor" target="_blank"><img src="https://opencollective.com/nest/sponsors/badge.svg" alt="Sponsors on Open Collective" /></a>
-  <a href="https://paypal.me/kamilmysliwiec" target="_blank"><img src="https://img.shields.io/badge/Donate-PayPal-ff3f59.svg" alt="Donate us"/></a>
-    <a href="https://opencollective.com/nest#sponsor"  target="_blank"><img src="https://img.shields.io/badge/Support%20us-Open%20Collective-41B883.svg" alt="Support us"></a>
-  <a href="https://twitter.com/nestframework" target="_blank"><img src="https://img.shields.io/twitter/follow/nestframework.svg?style=social&label=Follow" alt="Follow us on Twitter"></a>
-</p>
-  <!--[![Backers on Open Collective](https://opencollective.com/nest/backers/badge.svg)](https://opencollective.com/nest#backer)
-  [![Sponsors on Open Collective](https://opencollective.com/nest/sponsors/badge.svg)](https://opencollective.com/nest#sponsor)-->
-
-## Description
-
-[Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
-
-## Project setup
+## Rodar localmente
 
 ```bash
-$ npm install
+pnpm start:dev   # porta 3333, hot reload
+pnpm test        # testes unitários
+pnpm test:e2e    # testes e2e
+pnpm test:cov    # cobertura
 ```
 
-## Compile and run the project
+## Variáveis de ambiente
 
-```bash
-# development
-$ npm run start
-
-# watch mode
-$ npm run start:dev
-
-# production mode
-$ npm run start:prod
-```
-
-## Run tests
-
-```bash
-# unit tests
-$ npm run test
-
-# e2e tests
-$ npm run test:e2e
-
-# test coverage
-$ npm run test:cov
-```
-
-## Deployment
-
-When you're ready to deploy your NestJS application to production, there are some key steps you can take to ensure it runs as efficiently as possible. Check out the [deployment documentation](https://docs.nestjs.com/deployment) for more information.
-
-If you are looking for a cloud-based platform to deploy your NestJS application, check out [Mau](https://mau.nestjs.com), our official platform for deploying NestJS applications on AWS. Mau makes deployment straightforward and fast, requiring just a few simple steps:
-
-```bash
-$ npm install -g @nestjs/mau
-$ mau deploy
-```
-
-With Mau, you can deploy your application in just a few clicks, allowing you to focus on building features rather than managing infrastructure.
-
-## Resources
-
-Check out a few resources that may come in handy when working with NestJS:
-
-- Visit the [NestJS Documentation](https://docs.nestjs.com) to learn more about the framework.
-- For questions and support, please visit our [Discord channel](https://discord.gg/G7Qnnhy).
-- To dive deeper and get more hands-on experience, check out our official video [courses](https://courses.nestjs.com/).
-- Deploy your application to AWS with the help of [NestJS Mau](https://mau.nestjs.com) in just a few clicks.
-- Visualize your application graph and interact with the NestJS application in real-time using [NestJS Devtools](https://devtools.nestjs.com).
-- Need help with your project (part-time to full-time)? Check out our official [enterprise support](https://enterprise.nestjs.com).
-- To stay in the loop and get updates, follow us on [X](https://x.com/nestframework) and [LinkedIn](https://linkedin.com/company/nestjs).
-- Looking for a job, or have a job to offer? Check out our official [Jobs board](https://jobs.nestjs.com).
-
-## Support
-
-Nest is an MIT-licensed open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).
-
-## Stay in touch
-
-- Author - [Kamil Myśliwiec](https://twitter.com/kammysliwiec)
-- Website - [https://nestjs.com](https://nestjs.com/)
-- Twitter - [@nestframework](https://twitter.com/nestframework)
-
-## License
-
-Nest is [MIT licensed](https://github.com/nestjs/nest/blob/master/LICENSE).
+Veja `apps/api/.env.example` para a lista completa com descrições.

--- a/apps/api/src/auth/auth.guard.spec.ts
+++ b/apps/api/src/auth/auth.guard.spec.ts
@@ -4,7 +4,7 @@ import { Reflector } from '@nestjs/core';
 import { AuthGuard } from './auth.guard';
 
 const mockVerifyToken = jest.fn();
-const mockConfigGet = jest.fn().mockReturnValue('http://localhost:3000');
+const mockConfigGet = jest.fn().mockReturnValue('http://localhost:3000,https://luppin.app');
 
 const makeCtx = (authHeader?: string): ExecutionContext =>
   ({
@@ -24,8 +24,8 @@ describe('AuthGuard', () => {
     jest.resetAllMocks();
 
     reflector = { getAllAndOverride: jest.fn() } as unknown as jest.Mocked<Reflector>;
-    config = { get: mockConfigGet } as unknown as jest.Mocked<ConfigService>;
-    mockConfigGet.mockReturnValue('http://localhost:3000');
+    config = { getOrThrow: mockConfigGet } as unknown as jest.Mocked<ConfigService>;
+    mockConfigGet.mockReturnValue('http://localhost:3000,https://luppin.app');
 
     guard = new AuthGuard({ verifyToken: mockVerifyToken }, reflector, config);
   });
@@ -76,7 +76,7 @@ describe('AuthGuard', () => {
     expect(result).toBe(true);
     expect(request.user).toEqual({ userId: 'user_123' });
     expect(mockVerifyToken).toHaveBeenCalledWith('valid-token', {
-      authorizedParties: ['http://localhost:3000'],
+      authorizedParties: ['http://localhost:3000', 'https://luppin.app'],
     });
   });
 });

--- a/apps/api/src/auth/auth.guard.spec.ts
+++ b/apps/api/src/auth/auth.guard.spec.ts
@@ -1,33 +1,39 @@
 import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Reflector } from '@nestjs/core';
 import { AuthGuard } from './auth.guard';
 
 const mockVerifyToken = jest.fn();
+const mockConfigGet = jest.fn().mockReturnValue('http://localhost:3000');
+
+const makeCtx = (authHeader?: string): ExecutionContext =>
+  ({
+    getHandler: jest.fn(),
+    getClass: jest.fn(),
+    switchToHttp: () => ({
+      getRequest: () => ({ headers: { authorization: authHeader }, user: undefined }),
+    }),
+  }) as unknown as ExecutionContext;
 
 describe('AuthGuard', () => {
   let guard: AuthGuard;
   let reflector: jest.Mocked<Reflector>;
+  let config: jest.Mocked<ConfigService>;
 
   beforeEach(() => {
-    reflector = {
-      getAllAndOverride: jest.fn(),
-    } as unknown as jest.Mocked<Reflector>;
+    jest.resetAllMocks();
 
-    guard = new AuthGuard({ verifyToken: mockVerifyToken }, reflector);
+    reflector = { getAllAndOverride: jest.fn() } as unknown as jest.Mocked<Reflector>;
+    config = { get: mockConfigGet } as unknown as jest.Mocked<ConfigService>;
+    mockConfigGet.mockReturnValue('http://localhost:3000');
 
-    jest.clearAllMocks();
+    guard = new AuthGuard({ verifyToken: mockVerifyToken }, reflector, config);
   });
 
   it('bypasses guard for @Public() routes', async () => {
     reflector.getAllAndOverride.mockReturnValue(true);
 
-    const ctx = {
-      getHandler: jest.fn(),
-      getClass: jest.fn(),
-      switchToHttp: () => ({ getRequest: () => ({ headers: {} }) }),
-    } as unknown as ExecutionContext;
-
-    const result = await guard.canActivate(ctx);
+    const result = await guard.canActivate(makeCtx());
 
     expect(result).toBe(true);
     expect(mockVerifyToken).not.toHaveBeenCalled();
@@ -36,13 +42,7 @@ describe('AuthGuard', () => {
   it('throws UnauthorizedException when Authorization header is missing', async () => {
     reflector.getAllAndOverride.mockReturnValue(false);
 
-    const ctx = {
-      getHandler: jest.fn(),
-      getClass: jest.fn(),
-      switchToHttp: () => ({ getRequest: () => ({ headers: {} }) }),
-    } as unknown as ExecutionContext;
-
-    await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
+    await expect(guard.canActivate(makeCtx())).rejects.toThrow(UnauthorizedException);
     expect(mockVerifyToken).not.toHaveBeenCalled();
   });
 
@@ -50,25 +50,21 @@ describe('AuthGuard', () => {
     reflector.getAllAndOverride.mockReturnValue(false);
     mockVerifyToken.mockRejectedValue(new Error('Token invalid'));
 
-    const ctx = {
-      getHandler: jest.fn(),
-      getClass: jest.fn(),
-      switchToHttp: () => ({
-        getRequest: () => ({ headers: { authorization: 'Bearer bad-token' } }),
-      }),
-    } as unknown as ExecutionContext;
+    await expect(guard.canActivate(makeCtx('Bearer bad-token'))).rejects.toThrow(UnauthorizedException);
+  });
 
-    await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
+  it('throws UnauthorizedException when azp is not in authorizedParties', async () => {
+    reflector.getAllAndOverride.mockReturnValue(false);
+    mockVerifyToken.mockRejectedValue(new Error('azp is not in authorizedParties'));
+
+    await expect(guard.canActivate(makeCtx('Bearer token-wrong-azp'))).rejects.toThrow(UnauthorizedException);
   });
 
   it('returns true and sets request.user when token is valid', async () => {
     reflector.getAllAndOverride.mockReturnValue(false);
     mockVerifyToken.mockResolvedValue({ sub: 'user_123' });
 
-    const request = {
-      headers: { authorization: 'Bearer valid-token' },
-      user: undefined as { userId: string } | undefined,
-    };
+    const request = { headers: { authorization: 'Bearer valid-token' }, user: undefined };
     const ctx = {
       getHandler: jest.fn(),
       getClass: jest.fn(),
@@ -79,5 +75,8 @@ describe('AuthGuard', () => {
 
     expect(result).toBe(true);
     expect(request.user).toEqual({ userId: 'user_123' });
+    expect(mockVerifyToken).toHaveBeenCalledWith('valid-token', {
+      authorizedParties: ['http://localhost:3000'],
+    });
   });
 });

--- a/apps/api/src/auth/auth.guard.ts
+++ b/apps/api/src/auth/auth.guard.ts
@@ -21,11 +21,17 @@ interface AuthenticatedRequest {
 
 @Injectable()
 export class AuthGuard implements CanActivate {
+  private readonly authorizedParties: string[];
+
   constructor(
     @Inject(AUTH_CLIENT) private readonly clerkClient: ClerkClient,
     private readonly reflector: Reflector,
-    private readonly config: ConfigService,
-  ) {}
+    config: ConfigService,
+  ) {
+    this.authorizedParties = config
+      .getOrThrow<string>('CLERK_AUTHORIZED_PARTIES')
+      .split(',');
+  }
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
@@ -41,10 +47,9 @@ export class AuthGuard implements CanActivate {
     if (!token) throw new UnauthorizedException('Missing authorization token');
 
     try {
-      const authorizedParties = this.config
-        .get<string>('CLERK_AUTHORIZED_PARTIES', 'http://localhost:3000')
-        .split(',');
-      const payload = await this.clerkClient.verifyToken(token, { authorizedParties });
+      const payload = await this.clerkClient.verifyToken(token, {
+        authorizedParties: this.authorizedParties,
+      });
       request.user = { userId: payload.sub };
       return true;
     } catch {

--- a/apps/api/src/auth/auth.guard.ts
+++ b/apps/api/src/auth/auth.guard.ts
@@ -5,12 +5,13 @@ import {
   Injectable,
   UnauthorizedException,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Reflector } from '@nestjs/core';
 import { IS_PUBLIC_KEY } from './public.decorator';
 import { AUTH_CLIENT } from './auth.constants';
 
 export interface ClerkClient {
-  verifyToken(token: string): Promise<{ sub: string }>;
+  verifyToken(token: string, options?: { authorizedParties?: string[] }): Promise<{ sub: string }>;
 }
 
 interface AuthenticatedRequest {
@@ -23,6 +24,7 @@ export class AuthGuard implements CanActivate {
   constructor(
     @Inject(AUTH_CLIENT) private readonly clerkClient: ClerkClient,
     private readonly reflector: Reflector,
+    private readonly config: ConfigService,
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -39,7 +41,10 @@ export class AuthGuard implements CanActivate {
     if (!token) throw new UnauthorizedException('Missing authorization token');
 
     try {
-      const payload = await this.clerkClient.verifyToken(token);
+      const authorizedParties = this.config
+        .get<string>('CLERK_AUTHORIZED_PARTIES', 'http://localhost:3000')
+        .split(',');
+      const payload = await this.clerkClient.verifyToken(token, { authorizedParties });
       request.user = { userId: payload.sub };
       return true;
     } catch {

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,36 +1,15 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Luppa Web
 
-## Getting Started
+Frontend Next.js do Luppa. Para setup completo veja o [README raiz](../../README.md).
 
-First, run the development server:
+## Rodar localmente
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+pnpm dev     # porta 3000, hot reload
+pnpm build   # build de produção
+pnpm test    # testes
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## Variáveis de ambiente
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+Veja `apps/web/.env.example` para a lista completa com descrições.


### PR DESCRIPTION
## Summary

- `AuthGuard` agora lê `CLERK_AUTHORIZED_PARTIES` (lista separada por vírgula) e passa ao `verifyToken`
- Resolve 401 causado por tokens com campo `azp` não reconhecido
- Valor configurado no Railway: `http://localhost:3000,https://luppin.app`
- `.env.example` atualizado com a nova variável

## Test plan

- [x] 5 testes no AuthGuard: rota pública, sem token, token inválido, azp não autorizado, token válido com authorizedParties
- [x] 25 testes passando na API

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)