### PR TITLE
fix: use standalone verifyToken from @clerk/backend

### DIFF
--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
-import { createClerkClient } from '@clerk/backend';
+import { verifyToken } from '@clerk/backend';
 import { ConfigService } from '@nestjs/config';
 import { AuthGuard } from './auth.guard';
 import { AUTH_CLIENT } from './auth.constants';
@@ -10,8 +10,13 @@ import { AUTH_CLIENT } from './auth.constants';
     {
       provide: AUTH_CLIENT,
       inject: [ConfigService],
-      useFactory: (config: ConfigService) =>
-        createClerkClient({ secretKey: config.getOrThrow('CLERK_SECRET_KEY') }),
+      useFactory: (config: ConfigService) => {
+        const secretKey = config.getOrThrow<string>('CLERK_SECRET_KEY');
+        return {
+          verifyToken: (token: string, options?: { authorizedParties?: string[] }) =>
+            verifyToken(token, { secretKey, ...options }),
+        };
+      },
     },
     {
       provide: APP_GUARD,


### PR DESCRIPTION
## Problema

`createClerkClient` no `@clerk/backend` v3 não expõe `verifyToken` diretamente no objeto retornado, causando `TypeError: this.clerkClient.verifyToken is not a function` em todas as requests autenticadas.

## Solução

Substituir o `createClerkClient` por um wrapper que usa a função standalone `verifyToken` do `@clerk/backend`, injetando o `secretKey` via factory.

## Test plan

- [x] 25 testes passando
- [x] Testado manualmente: POST /invoices retorna 201 com token válido

🤖 Generated with [Claude Code](https://claude.com/claude-code)