### PR TITLE
fix: prefix storage paths by environment (dev/ vs prod/)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,4 +1,5 @@
 # Application
+# Determines storage path prefix: 'dev/' for non-production, 'prod/' for production
 NODE_ENV=development
 PORT=3333
 

--- a/apps/api/src/invoices/invoices.service.spec.ts
+++ b/apps/api/src/invoices/invoices.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { InternalServerErrorException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InvoicesService } from './invoices.service';
 import { InvoicesRepository } from './invoices.repository';
@@ -10,47 +11,51 @@ const mockStorageService = { upload: jest.fn() };
 const mockInvoicesRepository = { create: jest.fn() };
 const mockEventEmitter = { emit: jest.fn() };
 
+const file = {
+  originalname: 'fatura.pdf',
+  buffer: Buffer.from('pdf'),
+  mimetype: 'application/pdf',
+} as Express.Multer.File;
+
+async function createService(nodeEnv: string): Promise<InvoicesService> {
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      InvoicesService,
+      { provide: StorageService, useValue: mockStorageService },
+      { provide: InvoicesRepository, useValue: mockInvoicesRepository },
+      { provide: EventEmitter2, useValue: mockEventEmitter },
+      { provide: ConfigService, useValue: { get: jest.fn().mockReturnValue(nodeEnv) } },
+    ],
+  }).compile();
+  return module.get<InvoicesService>(InvoicesService);
+}
+
 describe('InvoicesService', () => {
-  let service: InvoicesService;
+  beforeEach(() => jest.resetAllMocks());
 
-  beforeEach(async () => {
-    jest.resetAllMocks();
+  describe('create (development)', () => {
+    let service: InvoicesService;
 
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        InvoicesService,
-        { provide: StorageService, useValue: mockStorageService },
-        { provide: InvoicesRepository, useValue: mockInvoicesRepository },
-        { provide: EventEmitter2, useValue: mockEventEmitter },
-      ],
-    }).compile();
+    beforeEach(async () => {
+      service = await createService('development');
+    });
 
-    service = module.get<InvoicesService>(InvoicesService);
-  });
-
-  describe('create', () => {
-    const file = {
-      originalname: 'fatura.pdf',
-      buffer: Buffer.from('pdf'),
-      mimetype: 'application/pdf',
-    } as Express.Multer.File;
-
-    it('should upload, create invoice, emit event and return invoiceId', async () => {
-      mockStorageService.upload.mockResolvedValue('user-1/fatura.pdf');
-      mockInvoicesRepository.create.mockResolvedValue({ id: 'inv-1', userId: 'user-1', storagePath: 'user-1/fatura.pdf' });
+    it('should upload under dev/ prefix, create invoice, emit event and return invoiceId', async () => {
+      mockStorageService.upload.mockResolvedValue('dev/user-1/fatura.pdf');
+      mockInvoicesRepository.create.mockResolvedValue({ id: 'inv-1', userId: 'user-1', storagePath: 'dev/user-1/fatura.pdf' });
 
       const result = await service.create('user-1', file);
 
       expect(mockStorageService.upload).toHaveBeenCalledWith(
         'invoices',
-        expect.stringContaining('user-1/'),
+        expect.stringMatching(/^dev\/user-1\//),
         file.buffer,
         'application/pdf',
       );
       expect(mockInvoicesRepository.create).toHaveBeenCalledWith({
         userId: 'user-1',
         filename: 'fatura.pdf',
-        storagePath: 'user-1/fatura.pdf',
+        storagePath: 'dev/user-1/fatura.pdf',
       });
       expect(mockEventEmitter.emit).toHaveBeenCalledWith(
         'invoice.created',
@@ -68,11 +73,33 @@ describe('InvoicesService', () => {
     });
 
     it('should not emit event if repository create fails', async () => {
-      mockStorageService.upload.mockResolvedValue('user-1/fatura.pdf');
+      mockStorageService.upload.mockResolvedValue('dev/user-1/fatura.pdf');
       mockInvoicesRepository.create.mockRejectedValue(new Error('db error'));
 
       await expect(service.create('user-1', file)).rejects.toThrow();
       expect(mockEventEmitter.emit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('create (production)', () => {
+    let service: InvoicesService;
+
+    beforeEach(async () => {
+      service = await createService('production');
+    });
+
+    it('should upload under prod/ prefix', async () => {
+      mockStorageService.upload.mockResolvedValue('prod/user-1/fatura.pdf');
+      mockInvoicesRepository.create.mockResolvedValue({ id: 'inv-1', userId: 'user-1', storagePath: 'prod/user-1/fatura.pdf' });
+
+      await service.create('user-1', file);
+
+      expect(mockStorageService.upload).toHaveBeenCalledWith(
+        'invoices',
+        expect.stringMatching(/^prod\/user-1\//),
+        file.buffer,
+        'application/pdf',
+      );
     });
   });
 });

--- a/apps/api/src/invoices/invoices.service.ts
+++ b/apps/api/src/invoices/invoices.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { StorageService } from '../storage/storage.service';
 import { InvoicesRepository } from './invoices.repository';
@@ -6,16 +7,21 @@ import { InvoiceCreatedEvent } from './events/invoice-created.event';
 
 @Injectable()
 export class InvoicesService {
+  private readonly envPrefix: string;
+
   constructor(
     private readonly storageService: StorageService,
     private readonly invoicesRepository: InvoicesRepository,
     private readonly eventEmitter: EventEmitter2,
-  ) {}
+    config: ConfigService,
+  ) {
+    this.envPrefix = config.get<string>('NODE_ENV') === 'production' ? 'prod' : 'dev';
+  }
 
   async create(userId: string, file: Express.Multer.File): Promise<{ invoiceId: string }> {
     const storagePath = await this.storageService.upload(
       'invoices',
-      `${userId}/${Date.now()}-${file.originalname}`,
+      `${this.envPrefix}/${userId}/${Date.now()}-${file.originalname}`,
       file.buffer,
       file.mimetype,
     );


### PR DESCRIPTION
## Problema

Uploads locais e de produção iam para o mesmo bucket e paths no Supabase Storage, misturando dados de dev com dados reais de usuários.

## Solução

Prefixo no path derivado de `NODE_ENV` em tempo de startup:
- `dev/userId/timestamp-file.pdf` — qualquer ambiente não-production
- `prod/userId/timestamp-file.pdf` — production (Railway)

Nenhum bucket novo, nenhuma variável de ambiente nova, nenhuma mudança na interface do `StorageService`.

## Test plan

- [x] Teste dev: path começa com `dev/user-1/`
- [x] Teste prod: path começa com `prod/user-1/`
- [x] 26 testes passando

🤖 Generated with [Claude Code](https://claude.com/claude-code)