### PR TITLE
feat: ExtractionModule — Claude-powered PDF transaction extraction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,32 @@ pnpm dev              # dev server
 pnpm build            # production build
 ```
 
+## End of day
+
+When the user says they are ending the work session, always generate a daily note at:
+
+```
+/Users/ricardocolares/Documents/Obsidian Vault/Dailies/YYYY-MM-DD.md
+```
+
+Use today's date for the filename. Structure:
+
+```markdown
+# Daily — YYYY-MM-DD
+
+## O que foi discutido
+(topics discussed during the session)
+
+## Decisões
+(technical and product decisions made)
+
+## O que foi feito
+(issues worked on, PRs opened, tests written, etc.)
+
+## Próximos passos
+- [ ] pending actions the user mentioned before closing
+```
+
 ## Gitignored sensitive files
 
 - `apps/api/src/extraction/testdata/*.pdf` — real invoice PDFs (sensitive data, never commit)

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -8,6 +8,9 @@ CLERK_SECRET_KEY=sk_test_...
 # Comma-separated list of allowed frontend origins
 CLERK_AUTHORIZED_PARTIES=http://localhost:3000
 
+# Claude API (Anthropic)
+ANTHROPIC_API_KEY=sk-ant-...
+
 # Database (Supabase PostgreSQL)
 # Transaction pooler — used by the app at runtime (port 6543)
 DATABASE_URL=postgresql://postgres.[project-ref]:[password]@aws-0-[region].pooler.supabase.com:6543/postgres?pgbouncer=true

--- a/apps/api/.gitignore
+++ b/apps/api/.gitignore
@@ -3,3 +3,6 @@ node_modules
 .env
 
 /generated/prisma
+
+# Real invoice PDFs — sensitive data, never commit
+src/extraction/testdata/*.pdf

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,6 +21,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.95.1",
     "@clerk/backend": "^3.4.4",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.4",

--- a/apps/api/src/extraction/extraction.constants.ts
+++ b/apps/api/src/extraction/extraction.constants.ts
@@ -1,0 +1,3 @@
+export const ANTHROPIC_CLIENT = Symbol('ANTHROPIC_CLIENT');
+export const EXTRACTION_MODEL = 'claude-haiku-4-5-20251001';
+export const DEFAULT_CATEGORY = 'Other';

--- a/apps/api/src/extraction/extraction.module.ts
+++ b/apps/api/src/extraction/extraction.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import Anthropic from '@anthropic-ai/sdk';
+import { ExtractionService } from './extraction.service';
+import { ANTHROPIC_CLIENT } from './extraction.constants';
+
+@Module({
+  providers: [
+    {
+      provide: ANTHROPIC_CLIENT,
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) =>
+        new Anthropic({ apiKey: config.getOrThrow<string>('ANTHROPIC_API_KEY') }),
+    },
+    ExtractionService,
+  ],
+  exports: [ExtractionService],
+})
+export class ExtractionModule {}

--- a/apps/api/src/extraction/extraction.service.spec.ts
+++ b/apps/api/src/extraction/extraction.service.spec.ts
@@ -1,0 +1,94 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExtractionService } from './extraction.service';
+import { ANTHROPIC_CLIENT } from './extraction.constants';
+
+const mockAnthropicClient = { messages: { create: jest.fn() } };
+
+const pdf = Buffer.from('fake-pdf');
+
+function makeToolUseResponse(invoiceTotal: number, transactions: object[]) {
+  return {
+    content: [
+      {
+        type: 'tool_use',
+        input: { invoiceTotal, transactions },
+      },
+    ],
+  };
+}
+
+async function createService(): Promise<ExtractionService> {
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      ExtractionService,
+      { provide: ANTHROPIC_CLIENT, useValue: mockAnthropicClient },
+    ],
+  }).compile();
+  return module.get<ExtractionService>(ExtractionService);
+}
+
+describe('ExtractionService', () => {
+  let service: ExtractionService;
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+    service = await createService();
+  });
+
+  it('should return extracted transactions on success', async () => {
+    mockAnthropicClient.messages.create.mockResolvedValue(
+      makeToolUseResponse(100.0, [
+        { date: '2025-04-10', description: 'UBER *TRIP', amount: 60.0, type: 'debit' },
+        { date: '2025-04-15', description: 'NETFLIX', amount: 40.0, type: 'debit' },
+      ]),
+    );
+
+    const result = await service.extract(pdf);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      date: '2025-04-10',
+      description: 'UBER *TRIP',
+      amount: 60.0,
+      type: 'debit',
+      category: 'Other',
+    });
+    expect(result[1].category).toBe('Other');
+  });
+
+  it('should throw when Claude returns text instead of tool_use', async () => {
+    mockAnthropicClient.messages.create.mockResolvedValue({
+      content: [{ type: 'text', text: 'I found the following transactions...' }],
+    });
+
+    await expect(service.extract(pdf)).rejects.toThrow('Unexpected response format from Claude');
+  });
+
+  it('should throw when transaction sum diverges from invoiceTotal', async () => {
+    mockAnthropicClient.messages.create.mockResolvedValue(
+      makeToolUseResponse(100.0, [
+        { date: '2025-04-10', description: 'UBER *TRIP', amount: 60.0, type: 'debit' },
+        { date: '2025-04-15', description: 'NETFLIX', amount: 39.0, type: 'debit' },
+      ]),
+    );
+
+    await expect(service.extract(pdf)).rejects.toThrow('Sum check failed');
+  });
+
+  it('should throw when duplicate transactions are detected', async () => {
+    mockAnthropicClient.messages.create.mockResolvedValue(
+      makeToolUseResponse(120.0, [
+        { date: '2025-04-10', description: 'UBER *TRIP', amount: 60.0, type: 'debit' },
+        { date: '2025-04-10', description: 'UBER *TRIP', amount: 60.0, type: 'debit' },
+      ]),
+    );
+
+    await expect(service.extract(pdf)).rejects.toThrow('Duplicate transactions detected');
+  });
+
+  it('should propagate Anthropic SDK errors', async () => {
+    mockAnthropicClient.messages.create.mockRejectedValue(new Error('API error'));
+
+    await expect(service.extract(pdf)).rejects.toThrow('API error');
+  });
+});

--- a/apps/api/src/extraction/extraction.service.ts
+++ b/apps/api/src/extraction/extraction.service.ts
@@ -1,0 +1,105 @@
+import { Inject, Injectable } from '@nestjs/common';
+import Anthropic from '@anthropic-ai/sdk';
+import { ANTHROPIC_CLIENT, DEFAULT_CATEGORY, EXTRACTION_MODEL } from './extraction.constants';
+import { ExtractedTransaction } from './extraction.types';
+
+interface ClaudeExtractionResult {
+  invoiceTotal: number;
+  transactions: Array<{
+    date: string;
+    description: string;
+    amount: number;
+    type: 'debit' | 'credit';
+  }>;
+}
+
+const EXTRACTION_TOOL: Anthropic.Tool = {
+  name: 'extract_transactions',
+  description: 'Extract all transactions from a credit card invoice PDF',
+  input_schema: {
+    type: 'object' as const,
+    properties: {
+      invoiceTotal: {
+        type: 'number',
+        description: 'Total amount due on the invoice',
+      },
+      transactions: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            date: { type: 'string', description: 'Transaction date (YYYY-MM-DD)' },
+            description: { type: 'string', description: 'Merchant or transaction description' },
+            amount: { type: 'number', description: 'Transaction amount (positive)' },
+            type: { type: 'string', enum: ['debit', 'credit'] },
+          },
+          required: ['date', 'description', 'amount', 'type'],
+        },
+      },
+    },
+    required: ['invoiceTotal', 'transactions'],
+  },
+};
+
+@Injectable()
+export class ExtractionService {
+  constructor(@Inject(ANTHROPIC_CLIENT) private readonly client: Anthropic) {}
+
+  async extract(pdf: Buffer): Promise<ExtractedTransaction[]> {
+    const response = await this.client.messages.create({
+      model: EXTRACTION_MODEL,
+      max_tokens: 4096,
+      tools: [EXTRACTION_TOOL],
+      tool_choice: { type: 'tool', name: 'extract_transactions' },
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'document',
+              source: {
+                type: 'base64',
+                media_type: 'application/pdf',
+                data: pdf.toString('base64'),
+              },
+            },
+            {
+              type: 'text',
+              text: 'Extract all transactions from this credit card invoice. Include every line item.',
+            },
+          ],
+        },
+      ],
+    });
+
+    const toolUse = response.content.find((block) => block.type === 'tool_use');
+    if (!toolUse) {
+      throw new Error('Unexpected response format from Claude: expected tool_use block');
+    }
+
+    const result = toolUse.input as ClaudeExtractionResult;
+
+    this.validateSum(result);
+    this.validateDuplicates(result.transactions);
+
+    return result.transactions.map((t) => ({ ...t, category: DEFAULT_CATEGORY }));
+  }
+
+  private validateSum({ invoiceTotal, transactions }: ClaudeExtractionResult): void {
+    const debitSum = transactions.reduce((acc, t) => (t.type === 'debit' ? acc + t.amount : acc), 0);
+    if (Math.abs(debitSum - invoiceTotal) > 0.01) {
+      throw new Error(
+        `Sum check failed: transactions sum ${debitSum.toFixed(2)} differs from invoiceTotal ${invoiceTotal.toFixed(2)}`,
+      );
+    }
+  }
+
+  private validateDuplicates(transactions: ClaudeExtractionResult['transactions']): void {
+    const seen = new Set<string>();
+    for (const t of transactions) {
+      const key = `${t.date}|${t.description}|${t.amount}`;
+      if (seen.has(key)) throw new Error('Duplicate transactions detected in extraction result');
+      seen.add(key);
+    }
+  }
+}

--- a/apps/api/src/extraction/extraction.types.ts
+++ b/apps/api/src/extraction/extraction.types.ts
@@ -1,0 +1,8 @@
+export interface ExtractedTransaction {
+  date: string;
+  description: string;
+  amount: number;
+  type: 'debit' | 'credit';
+  // MVP: always 'Other' — updated to full union when categorization module is implemented
+  category: string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.95.1
+        version: 0.95.1
       '@clerk/backend':
         specifier: ^3.4.4
         version: 3.4.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -233,6 +236,15 @@ packages:
   '@angular-devkit/schematics@19.2.24':
     resolution: {integrity: sha512-lnw+ZM1Io+cJAkReC0NPDjqObL8NtKzKIkdgEEKC8CUmkhurYhedbicN8Y8NYHgG1uLd2GozW3+/QqPRZaN+Lw==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
+
+  '@anthropic-ai/sdk@0.95.1':
+    resolution: {integrity: sha512-OO9AF7hmAoU492c/mD7Q2cPqI2WNAj7rAPHlawgBeUgpwiboLRiDs+grsErGWeHHP9ZRWfzq2OVrODTt8aITVg==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -3280,6 +3292,10 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -4305,6 +4321,9 @@ packages:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -4687,6 +4706,11 @@ snapshots:
       rxjs: 7.8.1
     transitivePeerDependencies:
       - chokidar
+
+  '@anthropic-ai/sdk@0.95.1':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -8278,6 +8302,11 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -9324,6 +9353,8 @@ snapshots:
   tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## Summary

- `ExtractionService.extract(pdf: Buffer)` sends PDF as base64 document block to Claude API
- Output enforced via `tool_use` with strict schema — no free-form text parsing
- Post-extraction validations: sum check (±0.01 tolerance) and duplicate detection (single-pass, early exit)
- `ANTHROPIC_CLIENT` injected via Symbol token — fully mockable, no real API calls in tests
- `EXTRACTION_MODEL` constant (`claude-haiku-4-5-20251001`) as single touch point for model changes
- All transactions default to `category: 'Other'` (MVP — full categorization is a future epic)
- `testdata/*.pdf` gitignored — real invoice PDFs never committed

## Test plan

- [x] 5 unit tests: success path, invalid format, sum check failure, duplicate detection, SDK error propagation
- [x] 31/31 tests passing
- [ ] Manual test with real PDF after adding `ANTHROPIC_API_KEY` to Railway

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)