### PR TITLE
feat: create User record on first Clerk authentication via webhook

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -32,7 +32,8 @@
     "@supabase/supabase-js": "^2.105.4",
     "prisma": "^6.19.3",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "svix": "^1.93.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/apps/api/prisma/migrations/20260517000001_cascade_delete_user/migration.sql
+++ b/apps/api/prisma/migrations/20260517000001_cascade_delete_user/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "Invoice" DROP CONSTRAINT "Invoice_userId_fkey";
+ALTER TABLE "Invoice" ADD CONSTRAINT "Invoice_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "Transaction" DROP CONSTRAINT "Transaction_invoiceId_fkey";
+ALTER TABLE "Transaction" ADD CONSTRAINT "Transaction_invoiceId_fkey" FOREIGN KEY ("invoiceId") REFERENCES "Invoice"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -17,7 +17,7 @@ model User {
 model Invoice {
   id           String        @id @default(cuid())
   userId       String
-  user         User          @relation(fields: [userId], references: [id])
+  user         User          @relation(fields: [userId], references: [id], onDelete: Cascade)
   filename     String
   storagePath  String
   status       InvoiceStatus @default(PENDING)
@@ -28,7 +28,7 @@ model Invoice {
 model Transaction {
   id          String          @id @default(cuid())
   invoiceId   String
-  invoice     Invoice         @relation(fields: [invoiceId], references: [id])
+  invoice     Invoice         @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
   date        DateTime
   description String
   amount      Decimal  @db.Decimal(10, 2)

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -8,6 +8,7 @@ import { PrismaModule } from './prisma/prisma.module';
 import { AuthModule } from './auth/auth.module';
 import { InvoicesModule } from './invoices/invoices.module';
 import { TransactionsModule } from './transactions/transactions.module';
+import { UsersModule } from './users/users.module';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { TransactionsModule } from './transactions/transactions.module';
     HealthModule,
     InvoicesModule,
     TransactionsModule,
+    UsersModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/api/src/auth/auth.guard.spec.ts
+++ b/apps/api/src/auth/auth.guard.spec.ts
@@ -4,14 +4,19 @@ import { Reflector } from '@nestjs/core';
 import { AuthGuard } from './auth.guard';
 
 const mockVerifyToken = jest.fn();
-const mockConfigGet = jest.fn().mockReturnValue('http://localhost:3000,https://luppin.app');
+const mockConfigGet = jest
+  .fn()
+  .mockReturnValue('http://localhost:3000,https://luppin.app');
 
 const makeCtx = (authHeader?: string): ExecutionContext =>
   ({
     getHandler: jest.fn(),
     getClass: jest.fn(),
     switchToHttp: () => ({
-      getRequest: () => ({ headers: { authorization: authHeader }, user: undefined }),
+      getRequest: () => ({
+        headers: { authorization: authHeader },
+        user: undefined,
+      }),
     }),
   }) as unknown as ExecutionContext;
 
@@ -23,8 +28,12 @@ describe('AuthGuard', () => {
   beforeEach(() => {
     jest.resetAllMocks();
 
-    reflector = { getAllAndOverride: jest.fn() } as unknown as jest.Mocked<Reflector>;
-    config = { getOrThrow: mockConfigGet } as unknown as jest.Mocked<ConfigService>;
+    reflector = {
+      getAllAndOverride: jest.fn(),
+    } as unknown as jest.Mocked<Reflector>;
+    config = {
+      getOrThrow: mockConfigGet,
+    } as unknown as jest.Mocked<ConfigService>;
     mockConfigGet.mockReturnValue('http://localhost:3000,https://luppin.app');
 
     guard = new AuthGuard({ verifyToken: mockVerifyToken }, reflector, config);
@@ -42,7 +51,9 @@ describe('AuthGuard', () => {
   it('throws UnauthorizedException when Authorization header is missing', async () => {
     reflector.getAllAndOverride.mockReturnValue(false);
 
-    await expect(guard.canActivate(makeCtx())).rejects.toThrow(UnauthorizedException);
+    await expect(guard.canActivate(makeCtx())).rejects.toThrow(
+      UnauthorizedException,
+    );
     expect(mockVerifyToken).not.toHaveBeenCalled();
   });
 
@@ -50,21 +61,30 @@ describe('AuthGuard', () => {
     reflector.getAllAndOverride.mockReturnValue(false);
     mockVerifyToken.mockRejectedValue(new Error('Token invalid'));
 
-    await expect(guard.canActivate(makeCtx('Bearer bad-token'))).rejects.toThrow(UnauthorizedException);
+    await expect(
+      guard.canActivate(makeCtx('Bearer bad-token')),
+    ).rejects.toThrow(UnauthorizedException);
   });
 
   it('throws UnauthorizedException when azp is not in authorizedParties', async () => {
     reflector.getAllAndOverride.mockReturnValue(false);
-    mockVerifyToken.mockRejectedValue(new Error('azp is not in authorizedParties'));
+    mockVerifyToken.mockRejectedValue(
+      new Error('azp is not in authorizedParties'),
+    );
 
-    await expect(guard.canActivate(makeCtx('Bearer token-wrong-azp'))).rejects.toThrow(UnauthorizedException);
+    await expect(
+      guard.canActivate(makeCtx('Bearer token-wrong-azp')),
+    ).rejects.toThrow(UnauthorizedException);
   });
 
   it('returns true and sets request.user when token is valid', async () => {
     reflector.getAllAndOverride.mockReturnValue(false);
     mockVerifyToken.mockResolvedValue({ sub: 'user_123' });
 
-    const request = { headers: { authorization: 'Bearer valid-token' }, user: undefined };
+    const request = {
+      headers: { authorization: 'Bearer valid-token' },
+      user: undefined,
+    };
     const ctx = {
       getHandler: jest.fn(),
       getClass: jest.fn(),

--- a/apps/api/src/auth/auth.guard.ts
+++ b/apps/api/src/auth/auth.guard.ts
@@ -11,7 +11,10 @@ import { IS_PUBLIC_KEY } from './public.decorator';
 import { AUTH_CLIENT } from './auth.constants';
 
 export interface ClerkClient {
-  verifyToken(token: string, options?: { authorizedParties?: string[] }): Promise<{ sub: string }>;
+  verifyToken(
+    token: string,
+    options?: { authorizedParties?: string[] },
+  ): Promise<{ sub: string }>;
 }
 
 interface AuthenticatedRequest {

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -13,8 +13,10 @@ import { AUTH_CLIENT } from './auth.constants';
       useFactory: (config: ConfigService) => {
         const secretKey = config.getOrThrow<string>('CLERK_SECRET_KEY');
         return {
-          verifyToken: (token: string, options?: { authorizedParties?: string[] }) =>
-            verifyToken(token, { secretKey, ...options }),
+          verifyToken: (
+            token: string,
+            options?: { authorizedParties?: string[] },
+          ) => verifyToken(token, { secretKey, ...options }),
         };
       },
     },

--- a/apps/api/src/extraction/extraction.module.ts
+++ b/apps/api/src/extraction/extraction.module.ts
@@ -10,7 +10,9 @@ import { ANTHROPIC_CLIENT } from './extraction.constants';
       provide: ANTHROPIC_CLIENT,
       inject: [ConfigService],
       useFactory: (config: ConfigService) =>
-        new Anthropic({ apiKey: config.getOrThrow<string>('ANTHROPIC_API_KEY') }),
+        new Anthropic({
+          apiKey: config.getOrThrow<string>('ANTHROPIC_API_KEY'),
+        }),
     },
     ExtractionService,
   ],

--- a/apps/api/src/extraction/extraction.service.spec.ts
+++ b/apps/api/src/extraction/extraction.service.spec.ts
@@ -38,8 +38,18 @@ describe('ExtractionService', () => {
   it('should return extracted transactions on success', async () => {
     mockAnthropicClient.messages.create.mockResolvedValue(
       makeToolUseResponse(100.0, [
-        { date: '2025-04-10', description: 'UBER *TRIP', amount: 60.0, type: 'debit' },
-        { date: '2025-04-15', description: 'NETFLIX', amount: 40.0, type: 'debit' },
+        {
+          date: '2025-04-10',
+          description: 'UBER *TRIP',
+          amount: 60.0,
+          type: 'debit',
+        },
+        {
+          date: '2025-04-15',
+          description: 'NETFLIX',
+          amount: 40.0,
+          type: 'debit',
+        },
       ]),
     );
 
@@ -58,17 +68,31 @@ describe('ExtractionService', () => {
 
   it('should throw when Claude returns text instead of tool_use', async () => {
     mockAnthropicClient.messages.create.mockResolvedValue({
-      content: [{ type: 'text', text: 'I found the following transactions...' }],
+      content: [
+        { type: 'text', text: 'I found the following transactions...' },
+      ],
     });
 
-    await expect(service.extract(pdf)).rejects.toThrow('Unexpected response format from Claude');
+    await expect(service.extract(pdf)).rejects.toThrow(
+      'Unexpected response format from Claude',
+    );
   });
 
   it('should throw when transaction sum diverges from invoiceTotal', async () => {
     mockAnthropicClient.messages.create.mockResolvedValue(
       makeToolUseResponse(100.0, [
-        { date: '2025-04-10', description: 'UBER *TRIP', amount: 60.0, type: 'debit' },
-        { date: '2025-04-15', description: 'NETFLIX', amount: 39.0, type: 'debit' },
+        {
+          date: '2025-04-10',
+          description: 'UBER *TRIP',
+          amount: 60.0,
+          type: 'debit',
+        },
+        {
+          date: '2025-04-15',
+          description: 'NETFLIX',
+          amount: 39.0,
+          type: 'debit',
+        },
       ]),
     );
 
@@ -76,7 +100,9 @@ describe('ExtractionService', () => {
   });
 
   it('should propagate Anthropic SDK errors', async () => {
-    mockAnthropicClient.messages.create.mockRejectedValue(new Error('API error'));
+    mockAnthropicClient.messages.create.mockRejectedValue(
+      new Error('API error'),
+    );
 
     await expect(service.extract(pdf)).rejects.toThrow('API error');
   });

--- a/apps/api/src/extraction/extraction.service.ts
+++ b/apps/api/src/extraction/extraction.service.ts
@@ -1,6 +1,10 @@
 import { Inject, Injectable } from '@nestjs/common';
 import Anthropic from '@anthropic-ai/sdk';
-import { ANTHROPIC_CLIENT, DEFAULT_CATEGORY, EXTRACTION_MODEL } from './extraction.constants';
+import {
+  ANTHROPIC_CLIENT,
+  DEFAULT_CATEGORY,
+  EXTRACTION_MODEL,
+} from './extraction.constants';
 import { ExtractedTransaction } from './extraction.types';
 
 interface ClaudeExtractionResult {
@@ -28,9 +32,18 @@ const EXTRACTION_TOOL: Anthropic.Tool = {
         items: {
           type: 'object',
           properties: {
-            date: { type: 'string', description: 'Transaction date (YYYY-MM-DD)' },
-            description: { type: 'string', description: 'Merchant or transaction description' },
-            amount: { type: 'number', description: 'Transaction amount (positive)' },
+            date: {
+              type: 'string',
+              description: 'Transaction date (YYYY-MM-DD)',
+            },
+            description: {
+              type: 'string',
+              description: 'Merchant or transaction description',
+            },
+            amount: {
+              type: 'number',
+              description: 'Transaction amount (positive)',
+            },
             type: { type: 'string', enum: ['debit', 'credit'] },
           },
           required: ['date', 'description', 'amount', 'type'],
@@ -74,22 +87,35 @@ export class ExtractionService {
 
     const toolUse = response.content.find((block) => block.type === 'tool_use');
     if (!toolUse) {
-      throw new Error('Unexpected response format from Claude: expected tool_use block');
+      throw new Error(
+        'Unexpected response format from Claude: expected tool_use block',
+      );
     }
 
     const result = toolUse.input as ClaudeExtractionResult;
 
     if (!Array.isArray(result.transactions)) {
-      throw new Error(`Claude returned malformed extraction result: ${JSON.stringify(result)}`);
+      throw new Error(
+        `Claude returned malformed extraction result: ${JSON.stringify(result)}`,
+      );
     }
 
     this.validateSum(result);
 
-    return result.transactions.map((t) => ({ ...t, category: DEFAULT_CATEGORY }));
+    return result.transactions.map((t) => ({
+      ...t,
+      category: DEFAULT_CATEGORY,
+    }));
   }
 
-  private validateSum({ invoiceTotal, transactions }: ClaudeExtractionResult): void {
-    const debitSum = transactions.reduce((acc, t) => (t.type === 'debit' ? acc + t.amount : acc), 0);
+  private validateSum({
+    invoiceTotal,
+    transactions,
+  }: ClaudeExtractionResult): void {
+    const debitSum = transactions.reduce(
+      (acc, t) => (t.type === 'debit' ? acc + t.amount : acc),
+      0,
+    );
     if (Math.abs(debitSum - invoiceTotal) > 0.01) {
       throw new Error(
         `Sum check failed: transactions sum ${debitSum.toFixed(2)} differs from invoiceTotal ${invoiceTotal.toFixed(2)}`,

--- a/apps/api/src/invoices/invoices.controller.ts
+++ b/apps/api/src/invoices/invoices.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, FileTypeValidator, MaxFileSizeValidator, ParseFilePipe, Post, UploadedFile, UseInterceptors } from '@nestjs/common';
+import {
+  Controller,
+  FileTypeValidator,
+  MaxFileSizeValidator,
+  ParseFilePipe,
+  Post,
+  UploadedFile,
+  UseInterceptors,
+} from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { InvoicesService } from './invoices.service';

--- a/apps/api/src/invoices/invoices.repository.spec.ts
+++ b/apps/api/src/invoices/invoices.repository.spec.ts
@@ -45,7 +45,11 @@ describe('InvoicesRepository', () => {
 
       expect(result).toEqual(invoice);
       expect(mockPrisma.invoice.create).toHaveBeenCalledWith({
-        data: { userId: 'user-1', filename: 'fatura.pdf', storagePath: 'invoices/user-1/fatura.pdf' },
+        data: {
+          userId: 'user-1',
+          filename: 'fatura.pdf',
+          storagePath: 'invoices/user-1/fatura.pdf',
+        },
       });
     });
   });

--- a/apps/api/src/invoices/invoices.service.spec.ts
+++ b/apps/api/src/invoices/invoices.service.spec.ts
@@ -24,7 +24,10 @@ async function createService(nodeEnv: string): Promise<InvoicesService> {
       { provide: StorageService, useValue: mockStorageService },
       { provide: InvoicesRepository, useValue: mockInvoicesRepository },
       { provide: EventEmitter2, useValue: mockEventEmitter },
-      { provide: ConfigService, useValue: { get: jest.fn().mockReturnValue(nodeEnv) } },
+      {
+        provide: ConfigService,
+        useValue: { get: jest.fn().mockReturnValue(nodeEnv) },
+      },
     ],
   }).compile();
   return module.get<InvoicesService>(InvoicesService);
@@ -42,7 +45,11 @@ describe('InvoicesService', () => {
 
     it('should upload under dev/ prefix, create invoice, emit event and return invoiceId', async () => {
       mockStorageService.upload.mockResolvedValue('dev/user-1/fatura.pdf');
-      mockInvoicesRepository.create.mockResolvedValue({ id: 'inv-1', userId: 'user-1', storagePath: 'dev/user-1/fatura.pdf' });
+      mockInvoicesRepository.create.mockResolvedValue({
+        id: 'inv-1',
+        userId: 'user-1',
+        storagePath: 'dev/user-1/fatura.pdf',
+      });
 
       const result = await service.create('user-1', file);
 
@@ -65,9 +72,13 @@ describe('InvoicesService', () => {
     });
 
     it('should not create invoice if upload fails', async () => {
-      mockStorageService.upload.mockRejectedValue(new InternalServerErrorException('upload failed'));
+      mockStorageService.upload.mockRejectedValue(
+        new InternalServerErrorException('upload failed'),
+      );
 
-      await expect(service.create('user-1', file)).rejects.toThrow(InternalServerErrorException);
+      await expect(service.create('user-1', file)).rejects.toThrow(
+        InternalServerErrorException,
+      );
       expect(mockInvoicesRepository.create).not.toHaveBeenCalled();
       expect(mockEventEmitter.emit).not.toHaveBeenCalled();
     });
@@ -90,7 +101,11 @@ describe('InvoicesService', () => {
 
     it('should upload under prod/ prefix', async () => {
       mockStorageService.upload.mockResolvedValue('prod/user-1/fatura.pdf');
-      mockInvoicesRepository.create.mockResolvedValue({ id: 'inv-1', userId: 'user-1', storagePath: 'prod/user-1/fatura.pdf' });
+      mockInvoicesRepository.create.mockResolvedValue({
+        id: 'inv-1',
+        userId: 'user-1',
+        storagePath: 'prod/user-1/fatura.pdf',
+      });
 
       await service.create('user-1', file);
 

--- a/apps/api/src/invoices/invoices.service.ts
+++ b/apps/api/src/invoices/invoices.service.ts
@@ -16,10 +16,14 @@ export class InvoicesService {
     private readonly eventEmitter: EventEmitter2,
     config: ConfigService,
   ) {
-    this.envPrefix = config.get<string>('NODE_ENV') === 'production' ? 'prod' : 'dev';
+    this.envPrefix =
+      config.get<string>('NODE_ENV') === 'production' ? 'prod' : 'dev';
   }
 
-  async create(userId: string, file: Express.Multer.File): Promise<{ invoiceId: string }> {
+  async create(
+    userId: string,
+    file: Express.Multer.File,
+  ): Promise<{ invoiceId: string }> {
     const storagePath = await this.storageService.upload(
       INVOICES_BUCKET,
       `${this.envPrefix}/${userId}/${Date.now()}-${file.originalname}`,
@@ -33,7 +37,10 @@ export class InvoicesService {
       storagePath,
     });
 
-    this.eventEmitter.emit('invoice.created', new InvoiceCreatedEvent(invoice.id, userId, storagePath));
+    this.eventEmitter.emit(
+      'invoice.created',
+      new InvoiceCreatedEvent(invoice.id, userId, storagePath),
+    );
 
     return { invoiceId: invoice.id };
   }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -2,7 +2,7 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, { rawBody: true });
   await app.listen(process.env.PORT ?? 3333);
 }
 void bootstrap();

--- a/apps/api/src/storage/storage.service.spec.ts
+++ b/apps/api/src/storage/storage.service.spec.ts
@@ -28,21 +28,37 @@ describe('StorageService', () => {
   describe('upload', () => {
     it('should return the file path on success', async () => {
       mockSupabaseClient.storage.from.mockReturnValue({
-        upload: jest.fn().mockResolvedValue({ data: { path: 'user-1/file.pdf' }, error: null }),
+        upload: jest.fn().mockResolvedValue({
+          data: { path: 'user-1/file.pdf' },
+          error: null,
+        }),
       });
 
-      const result = await service.upload('invoices', 'user-1/file.pdf', Buffer.from('pdf'), 'application/pdf');
+      const result = await service.upload(
+        'invoices',
+        'user-1/file.pdf',
+        Buffer.from('pdf'),
+        'application/pdf',
+      );
 
       expect(result).toBe('user-1/file.pdf');
     });
 
     it('should throw InternalServerErrorException when Supabase returns an error', async () => {
       mockSupabaseClient.storage.from.mockReturnValue({
-        upload: jest.fn().mockResolvedValue({ data: null, error: { message: 'bucket not found' } }),
+        upload: jest.fn().mockResolvedValue({
+          data: null,
+          error: { message: 'bucket not found' },
+        }),
       });
 
       await expect(
-        service.upload('invoices', 'user-1/file.pdf', Buffer.from('pdf'), 'application/pdf'),
+        service.upload(
+          'invoices',
+          'user-1/file.pdf',
+          Buffer.from('pdf'),
+          'application/pdf',
+        ),
       ).rejects.toThrow(InternalServerErrorException);
     });
   });
@@ -51,7 +67,9 @@ describe('StorageService', () => {
     it('should return a Buffer with the file content on success', async () => {
       const fileContent = Buffer.from('pdf content');
       mockSupabaseClient.storage.from.mockReturnValue({
-        download: jest.fn().mockResolvedValue({ data: new Blob([fileContent]), error: null }),
+        download: jest
+          .fn()
+          .mockResolvedValue({ data: new Blob([fileContent]), error: null }),
       });
 
       const result = await service.download('invoices', 'user-1/file.pdf');
@@ -61,7 +79,10 @@ describe('StorageService', () => {
 
     it('should throw InternalServerErrorException when Supabase returns an error', async () => {
       mockSupabaseClient.storage.from.mockReturnValue({
-        download: jest.fn().mockResolvedValue({ data: null, error: { message: 'object not found' } }),
+        download: jest.fn().mockResolvedValue({
+          data: null,
+          error: { message: 'object not found' },
+        }),
       });
 
       await expect(
@@ -83,7 +104,10 @@ describe('StorageService', () => {
 
     it('should throw InternalServerErrorException when Supabase returns an error', async () => {
       mockSupabaseClient.storage.from.mockReturnValue({
-        remove: jest.fn().mockResolvedValue({ data: null, error: { message: 'object not found' } }),
+        remove: jest.fn().mockResolvedValue({
+          data: null,
+          error: { message: 'object not found' },
+        }),
       });
 
       await expect(

--- a/apps/api/src/storage/storage.service.ts
+++ b/apps/api/src/storage/storage.service.ts
@@ -1,16 +1,29 @@
-import { Inject, Injectable, InternalServerErrorException } from '@nestjs/common';
+import {
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { SUPABASE_CLIENT } from './storage.constants';
 
 @Injectable()
 export class StorageService {
-  constructor(@Inject(SUPABASE_CLIENT) private readonly supabase: SupabaseClient) {}
+  constructor(
+    @Inject(SUPABASE_CLIENT) private readonly supabase: SupabaseClient,
+  ) {}
 
-  async upload(bucket: string, path: string, file: Buffer, mimeType: string): Promise<string> {
-    const { data, error } = await this.supabase.storage.from(bucket).upload(path, file, {
-      contentType: mimeType,
-      upsert: false,
-    });
+  async upload(
+    bucket: string,
+    path: string,
+    file: Buffer,
+    mimeType: string,
+  ): Promise<string> {
+    const { data, error } = await this.supabase.storage
+      .from(bucket)
+      .upload(path, file, {
+        contentType: mimeType,
+        upsert: false,
+      });
 
     if (error || !data) {
       this.fail('upload', error?.message ?? 'no data returned');
@@ -20,7 +33,9 @@ export class StorageService {
   }
 
   async download(bucket: string, path: string): Promise<Buffer> {
-    const { data, error } = await this.supabase.storage.from(bucket).download(path);
+    const { data, error } = await this.supabase.storage
+      .from(bucket)
+      .download(path);
 
     if (error || !data) {
       this.fail('download', error?.message ?? 'no data returned');

--- a/apps/api/src/transactions/transactions.listener.spec.ts
+++ b/apps/api/src/transactions/transactions.listener.spec.ts
@@ -13,10 +13,20 @@ const mockInvoicesRepository = { updateStatus: jest.fn() };
 const mockStorageService = { download: jest.fn() };
 const mockExtractionService = { extract: jest.fn() };
 
-const event = new InvoiceCreatedEvent('inv-1', 'user-1', 'dev/user-1/fatura.pdf');
+const event = new InvoiceCreatedEvent(
+  'inv-1',
+  'user-1',
+  'dev/user-1/fatura.pdf',
+);
 const pdfBuffer = Buffer.from('pdf');
 const extracted: ExtractedTransaction[] = [
-  { date: '2026-04-05', description: 'IFOOD', amount: 45.9, type: 'debit', category: 'Other' },
+  {
+    date: '2026-04-05',
+    description: 'IFOOD',
+    amount: 45.9,
+    type: 'debit',
+    category: 'Other',
+  },
 ];
 
 describe('TransactionsListener', () => {
@@ -26,7 +36,10 @@ describe('TransactionsListener', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TransactionsListener,
-        { provide: TransactionsRepository, useValue: mockTransactionsRepository },
+        {
+          provide: TransactionsRepository,
+          useValue: mockTransactionsRepository,
+        },
         { provide: InvoicesRepository, useValue: mockInvoicesRepository },
         { provide: StorageService, useValue: mockStorageService },
         { provide: ExtractionService, useValue: mockExtractionService },
@@ -43,20 +56,34 @@ describe('TransactionsListener', () => {
 
     await listener.handleInvoiceCreated(event);
 
-    expect(mockStorageService.download).toHaveBeenCalledWith('invoices', event.storagePath);
+    expect(mockStorageService.download).toHaveBeenCalledWith(
+      'invoices',
+      event.storagePath,
+    );
     expect(mockExtractionService.extract).toHaveBeenCalledWith(pdfBuffer);
-    expect(mockTransactionsRepository.createMany).toHaveBeenCalledWith('inv-1', extracted);
-    expect(mockInvoicesRepository.updateStatus).toHaveBeenCalledWith('inv-1', InvoiceStatus.DONE);
+    expect(mockTransactionsRepository.createMany).toHaveBeenCalledWith(
+      'inv-1',
+      extracted,
+    );
+    expect(mockInvoicesRepository.updateStatus).toHaveBeenCalledWith(
+      'inv-1',
+      InvoiceStatus.DONE,
+    );
   });
 
   it('should mark invoice as FAILED and not save transactions when extraction throws', async () => {
     mockStorageService.download.mockResolvedValue(pdfBuffer);
-    mockExtractionService.extract.mockRejectedValue(new Error('sum check failed'));
+    mockExtractionService.extract.mockRejectedValue(
+      new Error('sum check failed'),
+    );
 
     await listener.handleInvoiceCreated(event);
 
     expect(mockTransactionsRepository.createMany).not.toHaveBeenCalled();
-    expect(mockInvoicesRepository.updateStatus).toHaveBeenCalledWith('inv-1', InvoiceStatus.FAILED);
+    expect(mockInvoicesRepository.updateStatus).toHaveBeenCalledWith(
+      'inv-1',
+      InvoiceStatus.FAILED,
+    );
   });
 
   it('should mark invoice as FAILED when PDF download throws', async () => {
@@ -66,6 +93,9 @@ describe('TransactionsListener', () => {
 
     expect(mockExtractionService.extract).not.toHaveBeenCalled();
     expect(mockTransactionsRepository.createMany).not.toHaveBeenCalled();
-    expect(mockInvoicesRepository.updateStatus).toHaveBeenCalledWith('inv-1', InvoiceStatus.FAILED);
+    expect(mockInvoicesRepository.updateStatus).toHaveBeenCalledWith(
+      'inv-1',
+      InvoiceStatus.FAILED,
+    );
   });
 });

--- a/apps/api/src/transactions/transactions.listener.ts
+++ b/apps/api/src/transactions/transactions.listener.ts
@@ -22,13 +22,28 @@ export class TransactionsListener {
   @OnEvent('invoice.created')
   async handleInvoiceCreated(event: InvoiceCreatedEvent): Promise<void> {
     try {
-      const pdf = await this.storageService.download(INVOICES_BUCKET, event.storagePath);
+      const pdf = await this.storageService.download(
+        INVOICES_BUCKET,
+        event.storagePath,
+      );
       const transactions = await this.extractionService.extract(pdf);
-      await this.transactionsRepository.createMany(event.invoiceId, transactions);
-      await this.invoicesRepository.updateStatus(event.invoiceId, InvoiceStatus.DONE);
+      await this.transactionsRepository.createMany(
+        event.invoiceId,
+        transactions,
+      );
+      await this.invoicesRepository.updateStatus(
+        event.invoiceId,
+        InvoiceStatus.DONE,
+      );
     } catch (error) {
-      this.logger.error(`Failed to process invoice ${event.invoiceId}`, error instanceof Error ? error.stack : String(error));
-      await this.invoicesRepository.updateStatus(event.invoiceId, InvoiceStatus.FAILED);
+      this.logger.error(
+        `Failed to process invoice ${event.invoiceId}`,
+        error instanceof Error ? error.stack : String(error),
+      );
+      await this.invoicesRepository.updateStatus(
+        event.invoiceId,
+        InvoiceStatus.FAILED,
+      );
     }
   }
 }

--- a/apps/api/src/transactions/transactions.repository.spec.ts
+++ b/apps/api/src/transactions/transactions.repository.spec.ts
@@ -11,8 +11,20 @@ const mockPrisma = {
 };
 
 const transactions: ExtractedTransaction[] = [
-  { date: '2026-04-05', description: 'IFOOD', amount: 45.9, type: 'debit', category: 'Other' },
-  { date: '2026-04-07', description: 'UBER', amount: 18.5, type: 'debit', category: 'Other' },
+  {
+    date: '2026-04-05',
+    description: 'IFOOD',
+    amount: 45.9,
+    type: 'debit',
+    category: 'Other',
+  },
+  {
+    date: '2026-04-07',
+    description: 'UBER',
+    amount: 18.5,
+    type: 'debit',
+    category: 'Other',
+  },
 ];
 
 describe('TransactionsRepository', () => {

--- a/apps/api/src/transactions/transactions.repository.ts
+++ b/apps/api/src/transactions/transactions.repository.ts
@@ -7,7 +7,10 @@ import { ExtractedTransaction } from '../extraction/extraction.types';
 export class TransactionsRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  async createMany(invoiceId: string, transactions: ExtractedTransaction[]): Promise<void> {
+  async createMany(
+    invoiceId: string,
+    transactions: ExtractedTransaction[],
+  ): Promise<void> {
     if (transactions.length === 0) return;
 
     await this.prisma.transaction.createMany({

--- a/apps/api/src/users/users.controller.spec.ts
+++ b/apps/api/src/users/users.controller.spec.ts
@@ -1,0 +1,71 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { UsersController } from './users.controller';
+import { UsersService } from './users.service';
+import { WebhookVerifier } from './webhook-verifier';
+
+const mockUsersService = {
+  handleUserCreated: jest.fn(),
+  handleUserDeleted: jest.fn(),
+};
+
+const mockWebhookVerifier = { verify: jest.fn() };
+
+const rawBody = Buffer.from(JSON.stringify({ type: 'user.created', data: { id: 'user_1' } }));
+const headers = { 'svix-id': 'msg_1', 'svix-timestamp': '1716000000', 'svix-signature': 'v1,abc' };
+
+function makeReq(body: Buffer) {
+  return { rawBody: body } as any;
+}
+
+describe('UsersController', () => {
+  let controller: UsersController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UsersController],
+      providers: [
+        { provide: UsersService, useValue: mockUsersService },
+        { provide: WebhookVerifier, useValue: mockWebhookVerifier },
+      ],
+    }).compile();
+
+    controller = module.get<UsersController>(UsersController);
+    jest.resetAllMocks();
+  });
+
+  it('should call handleUserCreated on user.created with valid signature', async () => {
+    mockWebhookVerifier.verify.mockReturnValue({ type: 'user.created', data: { id: 'user_1' } });
+
+    await controller.handleWebhook(makeReq(rawBody), headers);
+
+    expect(mockUsersService.handleUserCreated).toHaveBeenCalledWith('user_1');
+    expect(mockUsersService.handleUserDeleted).not.toHaveBeenCalled();
+  });
+
+  it('should call handleUserDeleted on user.deleted with valid signature', async () => {
+    const body = Buffer.from(JSON.stringify({ type: 'user.deleted', data: { id: 'user_1' } }));
+    mockWebhookVerifier.verify.mockReturnValue({ type: 'user.deleted', data: { id: 'user_1' } });
+
+    await controller.handleWebhook(makeReq(body), headers);
+
+    expect(mockUsersService.handleUserDeleted).toHaveBeenCalledWith('user_1');
+    expect(mockUsersService.handleUserCreated).not.toHaveBeenCalled();
+  });
+
+  it('should throw BadRequestException when signature is invalid', async () => {
+    mockWebhookVerifier.verify.mockImplementation(() => { throw new Error('Invalid signature'); });
+
+    await expect(controller.handleWebhook(makeReq(rawBody), headers)).rejects.toThrow(BadRequestException);
+    expect(mockUsersService.handleUserCreated).not.toHaveBeenCalled();
+  });
+
+  it('should return 200 without calling service for unknown event types', async () => {
+    mockWebhookVerifier.verify.mockReturnValue({ type: 'session.created', data: { id: 'user_1' } });
+
+    await controller.handleWebhook(makeReq(rawBody), headers);
+
+    expect(mockUsersService.handleUserCreated).not.toHaveBeenCalled();
+    expect(mockUsersService.handleUserDeleted).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/users/users.controller.spec.ts
+++ b/apps/api/src/users/users.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, RawBodyRequest } from '@nestjs/common';
+import { Request } from 'express';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 import { WebhookVerifier } from './webhook-verifier';
@@ -11,11 +12,17 @@ const mockUsersService = {
 
 const mockWebhookVerifier = { verify: jest.fn() };
 
-const rawBody = Buffer.from(JSON.stringify({ type: 'user.created', data: { id: 'user_1' } }));
-const headers = { 'svix-id': 'msg_1', 'svix-timestamp': '1716000000', 'svix-signature': 'v1,abc' };
+const rawBody = Buffer.from(
+  JSON.stringify({ type: 'user.created', data: { id: 'user_1' } }),
+);
+const headers = {
+  'svix-id': 'msg_1',
+  'svix-timestamp': '1716000000',
+  'svix-signature': 'v1,abc',
+};
 
-function makeReq(body: Buffer) {
-  return { rawBody: body } as any;
+function makeReq(body: Buffer): RawBodyRequest<Request> {
+  return { rawBody: body } as RawBodyRequest<Request>;
 }
 
 describe('UsersController', () => {
@@ -35,7 +42,10 @@ describe('UsersController', () => {
   });
 
   it('should call handleUserCreated on user.created with valid signature', async () => {
-    mockWebhookVerifier.verify.mockReturnValue({ type: 'user.created', data: { id: 'user_1' } });
+    mockWebhookVerifier.verify.mockReturnValue({
+      type: 'user.created',
+      data: { id: 'user_1' },
+    });
 
     await controller.handleWebhook(makeReq(rawBody), headers);
 
@@ -44,8 +54,13 @@ describe('UsersController', () => {
   });
 
   it('should call handleUserDeleted on user.deleted with valid signature', async () => {
-    const body = Buffer.from(JSON.stringify({ type: 'user.deleted', data: { id: 'user_1' } }));
-    mockWebhookVerifier.verify.mockReturnValue({ type: 'user.deleted', data: { id: 'user_1' } });
+    const body = Buffer.from(
+      JSON.stringify({ type: 'user.deleted', data: { id: 'user_1' } }),
+    );
+    mockWebhookVerifier.verify.mockReturnValue({
+      type: 'user.deleted',
+      data: { id: 'user_1' },
+    });
 
     await controller.handleWebhook(makeReq(body), headers);
 
@@ -54,14 +69,21 @@ describe('UsersController', () => {
   });
 
   it('should throw BadRequestException when signature is invalid', async () => {
-    mockWebhookVerifier.verify.mockImplementation(() => { throw new Error('Invalid signature'); });
+    mockWebhookVerifier.verify.mockImplementation(() => {
+      throw new Error('Invalid signature');
+    });
 
-    await expect(controller.handleWebhook(makeReq(rawBody), headers)).rejects.toThrow(BadRequestException);
+    await expect(
+      controller.handleWebhook(makeReq(rawBody), headers),
+    ).rejects.toThrow(BadRequestException);
     expect(mockUsersService.handleUserCreated).not.toHaveBeenCalled();
   });
 
   it('should return 200 without calling service for unknown event types', async () => {
-    mockWebhookVerifier.verify.mockReturnValue({ type: 'session.created', data: { id: 'user_1' } });
+    mockWebhookVerifier.verify.mockReturnValue({
+      type: 'session.created',
+      data: { id: 'user_1' },
+    });
 
     await controller.handleWebhook(makeReq(rawBody), headers);
 

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,0 +1,38 @@
+import { BadRequestException, Controller, Headers, Post, RawBodyRequest, Req } from '@nestjs/common';
+import { Request } from 'express';
+import { Public } from '../auth/public.decorator';
+import { UsersService } from './users.service';
+import { WebhookVerifier } from './webhook-verifier';
+
+interface ClerkWebhookEvent {
+  type: string;
+  data: { id: string };
+}
+
+@Controller('webhooks')
+export class UsersController {
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly webhookVerifier: WebhookVerifier,
+  ) {}
+
+  @Public()
+  @Post('clerk')
+  async handleWebhook(
+    @Req() req: RawBodyRequest<Request>,
+    @Headers() headers: Record<string, string>,
+  ): Promise<void> {
+    let event: ClerkWebhookEvent;
+    try {
+      event = this.webhookVerifier.verify(req.rawBody!, headers) as ClerkWebhookEvent;
+    } catch {
+      throw new BadRequestException('Invalid webhook signature');
+    }
+
+    if (event.type === 'user.created') {
+      await this.usersService.handleUserCreated(event.data.id);
+    } else if (event.type === 'user.deleted') {
+      await this.usersService.handleUserDeleted(event.data.id);
+    }
+  }
+}

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,4 +1,11 @@
-import { BadRequestException, Controller, Headers, Post, RawBodyRequest, Req } from '@nestjs/common';
+import {
+  BadRequestException,
+  Controller,
+  Headers,
+  Post,
+  RawBodyRequest,
+  Req,
+} from '@nestjs/common';
 import { Request } from 'express';
 import { Public } from '../auth/public.decorator';
 import { UsersService } from './users.service';
@@ -24,7 +31,10 @@ export class UsersController {
   ): Promise<void> {
     let event: ClerkWebhookEvent;
     try {
-      event = this.webhookVerifier.verify(req.rawBody!, headers) as ClerkWebhookEvent;
+      event = this.webhookVerifier.verify(
+        req.rawBody!,
+        headers,
+      ) as ClerkWebhookEvent;
     } catch {
       throw new BadRequestException('Invalid webhook signature');
     }

--- a/apps/api/src/users/users.module.ts
+++ b/apps/api/src/users/users.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { UsersController } from './users.controller';
+import { UsersService } from './users.service';
+import { UsersRepository } from './users.repository';
+import { WebhookVerifier } from './webhook-verifier';
+
+@Module({
+  controllers: [UsersController],
+  providers: [UsersService, UsersRepository, WebhookVerifier],
+})
+export class UsersModule {}

--- a/apps/api/src/users/users.repository.spec.ts
+++ b/apps/api/src/users/users.repository.spec.ts
@@ -25,11 +25,16 @@ describe('UsersRepository', () => {
   });
 
   it('should create a user with the given id', async () => {
-    mockPrisma.user.create.mockResolvedValue({ id: 'user_1', createdAt: new Date() });
+    mockPrisma.user.create.mockResolvedValue({
+      id: 'user_1',
+      createdAt: new Date(),
+    });
 
     await repository.create('user_1');
 
-    expect(mockPrisma.user.create).toHaveBeenCalledWith({ data: { id: 'user_1' } });
+    expect(mockPrisma.user.create).toHaveBeenCalledWith({
+      data: { id: 'user_1' },
+    });
   });
 
   it('should delete a user by id', async () => {
@@ -37,6 +42,8 @@ describe('UsersRepository', () => {
 
     await repository.delete('user_1');
 
-    expect(mockPrisma.user.delete).toHaveBeenCalledWith({ where: { id: 'user_1' } });
+    expect(mockPrisma.user.delete).toHaveBeenCalledWith({
+      where: { id: 'user_1' },
+    });
   });
 });

--- a/apps/api/src/users/users.repository.spec.ts
+++ b/apps/api/src/users/users.repository.spec.ts
@@ -1,0 +1,42 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UsersRepository } from './users.repository';
+import { PrismaService } from '../prisma/prisma.service';
+
+const mockPrisma = {
+  user: {
+    create: jest.fn(),
+    delete: jest.fn(),
+  },
+};
+
+describe('UsersRepository', () => {
+  let repository: UsersRepository;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UsersRepository,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    repository = module.get<UsersRepository>(UsersRepository);
+    jest.resetAllMocks();
+  });
+
+  it('should create a user with the given id', async () => {
+    mockPrisma.user.create.mockResolvedValue({ id: 'user_1', createdAt: new Date() });
+
+    await repository.create('user_1');
+
+    expect(mockPrisma.user.create).toHaveBeenCalledWith({ data: { id: 'user_1' } });
+  });
+
+  it('should delete a user by id', async () => {
+    mockPrisma.user.delete.mockResolvedValue({ id: 'user_1' });
+
+    await repository.delete('user_1');
+
+    expect(mockPrisma.user.delete).toHaveBeenCalledWith({ where: { id: 'user_1' } });
+  });
+});

--- a/apps/api/src/users/users.repository.ts
+++ b/apps/api/src/users/users.repository.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class UsersRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(id: string): Promise<void> {
+    await this.prisma.user.create({ data: { id } });
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.prisma.user.delete({ where: { id } });
+  }
+}

--- a/apps/api/src/users/users.service.spec.ts
+++ b/apps/api/src/users/users.service.spec.ts
@@ -1,0 +1,36 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UsersService } from './users.service';
+import { UsersRepository } from './users.repository';
+
+const mockUsersRepository = {
+  create: jest.fn(),
+  delete: jest.fn(),
+};
+
+describe('UsersService', () => {
+  let service: UsersService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UsersService,
+        { provide: UsersRepository, useValue: mockUsersRepository },
+      ],
+    }).compile();
+
+    service = module.get<UsersService>(UsersService);
+    jest.resetAllMocks();
+  });
+
+  it('should delegate handleUserCreated to repository.create', async () => {
+    await service.handleUserCreated('user_1');
+
+    expect(mockUsersRepository.create).toHaveBeenCalledWith('user_1');
+  });
+
+  it('should delegate handleUserDeleted to repository.delete', async () => {
+    await service.handleUserDeleted('user_1');
+
+    expect(mockUsersRepository.delete).toHaveBeenCalledWith('user_1');
+  });
+});

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { UsersRepository } from './users.repository';
+
+@Injectable()
+export class UsersService {
+  constructor(private readonly repository: UsersRepository) {}
+
+  async handleUserCreated(id: string): Promise<void> {
+    await this.repository.create(id);
+  }
+
+  async handleUserDeleted(id: string): Promise<void> {
+    await this.repository.delete(id);
+  }
+}

--- a/apps/api/src/users/webhook-verifier.ts
+++ b/apps/api/src/users/webhook-verifier.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Webhook } from 'svix';
+
+@Injectable()
+export class WebhookVerifier {
+  private readonly webhook: Webhook;
+
+  constructor(config: ConfigService) {
+    this.webhook = new Webhook(config.getOrThrow('CLERK_WEBHOOK_SECRET'));
+  }
+
+  verify(payload: Buffer, headers: Record<string, string>): unknown {
+    return this.webhook.verify(payload, headers);
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
+      svix:
+        specifier: ^1.93.0
+        version: 1.93.0
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.2.0
@@ -4239,6 +4242,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svix@1.93.0:
+    resolution: {integrity: sha512-AeCcSs+CrHNejZytBuvD4hw2B14rB7+Sq7ggwYgF22TgXh0uJJ3T4uVJSbSYKFSbO1AA4o470XoGgOYqu2fbSA==}
 
   symbol-observable@4.0.0:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
@@ -9285,6 +9291,10 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svix@1.93.0:
+    dependencies:
+      standardwebhooks: 1.0.0
 
   symbol-observable@4.0.0: {}
 


### PR DESCRIPTION
## Summary

- Adds `POST /webhooks/clerk` (público, sem AuthGuard) que recebe eventos do Clerk
- Valida assinatura Svix com `CLERK_WEBHOOK_SECRET` antes de processar qualquer evento
- `user.created` → cria registro em `User`; `user.deleted` → deleta em cascata
- Eventos desconhecidos são ignorados com 200
- `rawBody: true` no NestFactory para o Svix conseguir validar a assinatura

## Migrations

- `onDelete: Cascade` em `Invoice → User` e `Transaction → Invoice` (necessário para `user.deleted` funcionar sem violar FK)

## Setup necessário

Após o merge, adicionar no Railway:
- `CLERK_WEBHOOK_SECRET` — Clerk Dashboard → Webhooks → signing secret

E configurar o webhook no Clerk Dashboard:
- URL: `https://<api-url>/webhooks/clerk`
- Eventos: `user.created`, `user.deleted`

## Test plan

- [ ] 44/44 testes passando
- [ ] Configurar webhook no Clerk Dashboard apontando para a API
- [ ] Criar novo usuário → registro aparece em `User`
- [ ] Deletar usuário → registro some junto com Invoices e Transactions

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)