### PR TITLE
feat: GET /invoices + GET /invoices/:id

### DIFF
--- a/apps/api/src/invoices/dto/invoice-detail-response.dto.ts
+++ b/apps/api/src/invoices/dto/invoice-detail-response.dto.ts
@@ -32,7 +32,7 @@ export class InvoiceDetailResponseDto {
       filename: invoice.filename,
       status: invoice.status,
       createdAt: invoice.createdAt,
-      transactions: invoice.transactions.map(TransactionDto.from),
+      transactions: invoice.transactions.map((t) => TransactionDto.from(t)),
     };
   }
 }

--- a/apps/api/src/invoices/dto/invoice-detail-response.dto.ts
+++ b/apps/api/src/invoices/dto/invoice-detail-response.dto.ts
@@ -1,0 +1,38 @@
+import { Transaction } from '@prisma/client';
+import { InvoiceWithTransactions } from '../invoices.repository';
+
+class TransactionDto {
+  date: Date;
+  description: string;
+  amount: number;
+  type: string;
+  category: string | null;
+
+  static from(t: Transaction): TransactionDto {
+    return {
+      date: t.date,
+      description: t.description,
+      amount: Number(t.amount),
+      type: t.type,
+      category: t.category,
+    };
+  }
+}
+
+export class InvoiceDetailResponseDto {
+  id: string;
+  filename: string;
+  status: string;
+  createdAt: Date;
+  transactions: TransactionDto[];
+
+  static from(invoice: InvoiceWithTransactions): InvoiceDetailResponseDto {
+    return {
+      id: invoice.id,
+      filename: invoice.filename,
+      status: invoice.status,
+      createdAt: invoice.createdAt,
+      transactions: invoice.transactions.map(TransactionDto.from),
+    };
+  }
+}

--- a/apps/api/src/invoices/dto/invoice-response.dto.ts
+++ b/apps/api/src/invoices/dto/invoice-response.dto.ts
@@ -1,0 +1,17 @@
+import { Invoice } from '@prisma/client';
+
+export class InvoiceResponseDto {
+  id: string;
+  filename: string;
+  status: string;
+  createdAt: Date;
+
+  static from(invoice: Invoice): InvoiceResponseDto {
+    return {
+      id: invoice.id,
+      filename: invoice.filename,
+      status: invoice.status,
+      createdAt: invoice.createdAt,
+    };
+  }
+}

--- a/apps/api/src/invoices/invoices.controller.spec.ts
+++ b/apps/api/src/invoices/invoices.controller.spec.ts
@@ -1,8 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
 import { InvoicesController } from './invoices.controller';
 import { InvoicesService } from './invoices.service';
 
-const mockInvoicesService = { create: jest.fn() };
+const mockInvoicesService = {
+  create: jest.fn(),
+  findAll: jest.fn(),
+  findById: jest.fn(),
+};
 
 describe('InvoicesController', () => {
   let controller: InvoicesController;
@@ -36,6 +41,52 @@ describe('InvoicesController', () => {
         'user-1',
         pdfFile,
       );
+    });
+  });
+
+  describe('GET /invoices', () => {
+    it('should return list of invoices for the authenticated user', async () => {
+      const invoices = [
+        { id: 'inv-1', filename: 'fatura.pdf', status: 'DONE', createdAt: new Date() },
+      ];
+      mockInvoicesService.findAll.mockResolvedValue(invoices);
+
+      const result = await controller.findAll('user-1');
+
+      expect(mockInvoicesService.findAll).toHaveBeenCalledWith('user-1');
+      expect(result).toEqual(invoices);
+    });
+  });
+
+  describe('GET /invoices/:id', () => {
+    it('should return invoice detail with transactions mapped to DTO', async () => {
+      const txDate = new Date('2026-04-05');
+      const createdAt = new Date('2026-05-01');
+      const invoice = {
+        id: 'inv-1',
+        filename: 'fatura.pdf',
+        status: 'DONE',
+        createdAt,
+        transactions: [{ id: 'tx-1', invoiceId: 'inv-1', date: txDate, description: 'UBER', amount: 18.5, type: 'DEBIT', category: 'Other', createdAt: new Date() }],
+      };
+      mockInvoicesService.findById.mockResolvedValue(invoice);
+
+      const result = await controller.findOne('inv-1', 'user-1');
+
+      expect(mockInvoicesService.findById).toHaveBeenCalledWith('inv-1', 'user-1');
+      expect(result).toEqual({
+        id: 'inv-1',
+        filename: 'fatura.pdf',
+        status: 'DONE',
+        createdAt,
+        transactions: [{ date: txDate, description: 'UBER', amount: 18.5, type: 'DEBIT', category: 'Other' }],
+      });
+    });
+
+    it('should propagate NotFoundException when invoice is not found', async () => {
+      mockInvoicesService.findById.mockRejectedValue(new NotFoundException());
+
+      await expect(controller.findOne('inv-1', 'user-1')).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/apps/api/src/invoices/invoices.controller.spec.ts
+++ b/apps/api/src/invoices/invoices.controller.spec.ts
@@ -47,7 +47,12 @@ describe('InvoicesController', () => {
   describe('GET /invoices', () => {
     it('should return list of invoices for the authenticated user', async () => {
       const invoices = [
-        { id: 'inv-1', filename: 'fatura.pdf', status: 'DONE', createdAt: new Date() },
+        {
+          id: 'inv-1',
+          filename: 'fatura.pdf',
+          status: 'DONE',
+          createdAt: new Date(),
+        },
       ];
       mockInvoicesService.findAll.mockResolvedValue(invoices);
 
@@ -67,26 +72,50 @@ describe('InvoicesController', () => {
         filename: 'fatura.pdf',
         status: 'DONE',
         createdAt,
-        transactions: [{ id: 'tx-1', invoiceId: 'inv-1', date: txDate, description: 'UBER', amount: 18.5, type: 'DEBIT', category: 'Other', createdAt: new Date() }],
+        transactions: [
+          {
+            id: 'tx-1',
+            invoiceId: 'inv-1',
+            date: txDate,
+            description: 'UBER',
+            amount: 18.5,
+            type: 'DEBIT',
+            category: 'Other',
+            createdAt: new Date(),
+          },
+        ],
       };
       mockInvoicesService.findById.mockResolvedValue(invoice);
 
       const result = await controller.findOne('inv-1', 'user-1');
 
-      expect(mockInvoicesService.findById).toHaveBeenCalledWith('inv-1', 'user-1');
+      expect(mockInvoicesService.findById).toHaveBeenCalledWith(
+        'inv-1',
+        'user-1',
+      );
       expect(result).toEqual({
         id: 'inv-1',
         filename: 'fatura.pdf',
         status: 'DONE',
         createdAt,
-        transactions: [{ date: txDate, description: 'UBER', amount: 18.5, type: 'DEBIT', category: 'Other' }],
+        transactions: [
+          {
+            date: txDate,
+            description: 'UBER',
+            amount: 18.5,
+            type: 'DEBIT',
+            category: 'Other',
+          },
+        ],
       });
     });
 
     it('should propagate NotFoundException when invoice is not found', async () => {
       mockInvoicesService.findById.mockRejectedValue(new NotFoundException());
 
-      await expect(controller.findOne('inv-1', 'user-1')).rejects.toThrow(NotFoundException);
+      await expect(controller.findOne('inv-1', 'user-1')).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 });

--- a/apps/api/src/invoices/invoices.controller.ts
+++ b/apps/api/src/invoices/invoices.controller.ts
@@ -41,7 +41,7 @@ export class InvoicesController {
   @Get()
   async findAll(@CurrentUser() userId: string): Promise<InvoiceResponseDto[]> {
     const invoices = await this.invoicesService.findAll(userId);
-    return invoices.map(InvoiceResponseDto.from);
+    return invoices.map((i) => InvoiceResponseDto.from(i));
   }
 
   @Get(':id')

--- a/apps/api/src/invoices/invoices.controller.ts
+++ b/apps/api/src/invoices/invoices.controller.ts
@@ -1,7 +1,9 @@
 import {
   Controller,
   FileTypeValidator,
+  Get,
   MaxFileSizeValidator,
+  Param,
   ParseFilePipe,
   Post,
   UploadedFile,
@@ -10,6 +12,8 @@ import {
 import { FileInterceptor } from '@nestjs/platform-express';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { InvoicesService } from './invoices.service';
+import { InvoiceResponseDto } from './dto/invoice-response.dto';
+import { InvoiceDetailResponseDto } from './dto/invoice-detail-response.dto';
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
@@ -32,5 +36,20 @@ export class InvoicesController {
     file: Express.Multer.File,
   ): Promise<{ invoiceId: string }> {
     return this.invoicesService.create(userId, file);
+  }
+
+  @Get()
+  async findAll(@CurrentUser() userId: string): Promise<InvoiceResponseDto[]> {
+    const invoices = await this.invoicesService.findAll(userId);
+    return invoices.map(InvoiceResponseDto.from);
+  }
+
+  @Get(':id')
+  async findOne(
+    @Param('id') id: string,
+    @CurrentUser() userId: string,
+  ): Promise<InvoiceDetailResponseDto> {
+    const invoice = await this.invoicesService.findById(id, userId);
+    return InvoiceDetailResponseDto.from(invoice);
   }
 }

--- a/apps/api/src/invoices/invoices.repository.spec.ts
+++ b/apps/api/src/invoices/invoices.repository.spec.ts
@@ -6,6 +6,7 @@ const mockPrisma = {
   invoice: {
     create: jest.fn(),
     findFirst: jest.fn(),
+    findMany: jest.fn(),
   },
 };
 
@@ -71,6 +72,51 @@ describe('InvoicesRepository', () => {
       mockPrisma.invoice.findFirst.mockResolvedValue(null);
 
       const result = await repository.findById('inv-1', 'wrong-user');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findAllByUserId', () => {
+    it('should return invoices ordered by createdAt desc for the given userId', async () => {
+      const invoices = [
+        { id: 'inv-2', userId: 'user-1', createdAt: new Date('2026-05-10') },
+        { id: 'inv-1', userId: 'user-1', createdAt: new Date('2026-05-01') },
+      ];
+      mockPrisma.invoice.findMany.mockResolvedValue(invoices);
+
+      const result = await repository.findAllByUserId('user-1');
+
+      expect(mockPrisma.invoice.findMany).toHaveBeenCalledWith({
+        where: { userId: 'user-1' },
+        orderBy: { createdAt: 'desc' },
+      });
+      expect(result).toBe(invoices);
+    });
+  });
+
+  describe('findByIdWithTransactions', () => {
+    it('should return invoice with transactions when userId matches', async () => {
+      const invoice = {
+        id: 'inv-1',
+        userId: 'user-1',
+        transactions: [{ id: 'tx-1', amount: 45.9 }],
+      };
+      mockPrisma.invoice.findFirst.mockResolvedValue(invoice);
+
+      const result = await repository.findByIdWithTransactions('inv-1', 'user-1');
+
+      expect(mockPrisma.invoice.findFirst).toHaveBeenCalledWith({
+        where: { id: 'inv-1', userId: 'user-1' },
+        include: { transactions: true },
+      });
+      expect(result).toBe(invoice);
+    });
+
+    it('should return null when invoice belongs to another user', async () => {
+      mockPrisma.invoice.findFirst.mockResolvedValue(null);
+
+      const result = await repository.findByIdWithTransactions('inv-1', 'other-user');
 
       expect(result).toBeNull();
     });

--- a/apps/api/src/invoices/invoices.repository.spec.ts
+++ b/apps/api/src/invoices/invoices.repository.spec.ts
@@ -104,7 +104,10 @@ describe('InvoicesRepository', () => {
       };
       mockPrisma.invoice.findFirst.mockResolvedValue(invoice);
 
-      const result = await repository.findByIdWithTransactions('inv-1', 'user-1');
+      const result = await repository.findByIdWithTransactions(
+        'inv-1',
+        'user-1',
+      );
 
       expect(mockPrisma.invoice.findFirst).toHaveBeenCalledWith({
         where: { id: 'inv-1', userId: 'user-1' },
@@ -116,7 +119,10 @@ describe('InvoicesRepository', () => {
     it('should return null when invoice belongs to another user', async () => {
       mockPrisma.invoice.findFirst.mockResolvedValue(null);
 
-      const result = await repository.findByIdWithTransactions('inv-1', 'other-user');
+      const result = await repository.findByIdWithTransactions(
+        'inv-1',
+        'other-user',
+      );
 
       expect(result).toBeNull();
     });

--- a/apps/api/src/invoices/invoices.repository.ts
+++ b/apps/api/src/invoices/invoices.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Invoice, InvoiceStatus } from '@prisma/client';
+import { Invoice, InvoiceStatus, Transaction } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 
 interface CreateInvoiceData {
@@ -7,6 +7,8 @@ interface CreateInvoiceData {
   filename: string;
   storagePath: string;
 }
+
+export type InvoiceWithTransactions = Invoice & { transactions: Transaction[] };
 
 @Injectable()
 export class InvoicesRepository {
@@ -18,6 +20,20 @@ export class InvoicesRepository {
 
   async findById(id: string, userId: string): Promise<Invoice | null> {
     return this.prisma.invoice.findFirst({ where: { id, userId } });
+  }
+
+  async findAllByUserId(userId: string): Promise<Invoice[]> {
+    return this.prisma.invoice.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async findByIdWithTransactions(id: string, userId: string): Promise<InvoiceWithTransactions | null> {
+    return this.prisma.invoice.findFirst({
+      where: { id, userId },
+      include: { transactions: true },
+    });
   }
 
   async updateStatus(id: string, status: InvoiceStatus): Promise<void> {

--- a/apps/api/src/invoices/invoices.repository.ts
+++ b/apps/api/src/invoices/invoices.repository.ts
@@ -29,7 +29,10 @@ export class InvoicesRepository {
     });
   }
 
-  async findByIdWithTransactions(id: string, userId: string): Promise<InvoiceWithTransactions | null> {
+  async findByIdWithTransactions(
+    id: string,
+    userId: string,
+  ): Promise<InvoiceWithTransactions | null> {
     return this.prisma.invoice.findFirst({
       where: { id, userId },
       include: { transactions: true },

--- a/apps/api/src/invoices/invoices.service.spec.ts
+++ b/apps/api/src/invoices/invoices.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { InternalServerErrorException } from '@nestjs/common';
+import { InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InvoicesService } from './invoices.service';
@@ -8,7 +8,11 @@ import { StorageService } from '../storage/storage.service';
 import { InvoiceCreatedEvent } from './events/invoice-created.event';
 
 const mockStorageService = { upload: jest.fn() };
-const mockInvoicesRepository = { create: jest.fn() };
+const mockInvoicesRepository = {
+  create: jest.fn(),
+  findAllByUserId: jest.fn(),
+  findByIdWithTransactions: jest.fn(),
+};
 const mockEventEmitter = { emit: jest.fn() };
 
 const file = {
@@ -115,6 +119,48 @@ describe('InvoicesService', () => {
         file.buffer,
         'application/pdf',
       );
+    });
+  });
+
+  describe('findAll', () => {
+    let service: InvoicesService;
+
+    beforeEach(async () => {
+      service = await createService('development');
+    });
+
+    it('should return invoices for the given userId', async () => {
+      const invoices = [{ id: 'inv-1', userId: 'user-1' }];
+      mockInvoicesRepository.findAllByUserId.mockResolvedValue(invoices);
+
+      const result = await service.findAll('user-1');
+
+      expect(mockInvoicesRepository.findAllByUserId).toHaveBeenCalledWith('user-1');
+      expect(result).toBe(invoices);
+    });
+  });
+
+  describe('findById', () => {
+    let service: InvoicesService;
+
+    beforeEach(async () => {
+      service = await createService('development');
+    });
+
+    it('should return the invoice with transactions when found', async () => {
+      const invoice = { id: 'inv-1', userId: 'user-1', transactions: [] };
+      mockInvoicesRepository.findByIdWithTransactions.mockResolvedValue(invoice);
+
+      const result = await service.findById('inv-1', 'user-1');
+
+      expect(mockInvoicesRepository.findByIdWithTransactions).toHaveBeenCalledWith('inv-1', 'user-1');
+      expect(result).toBe(invoice);
+    });
+
+    it('should throw NotFoundException when invoice is not found', async () => {
+      mockInvoicesRepository.findByIdWithTransactions.mockResolvedValue(null);
+
+      await expect(service.findById('inv-1', 'user-1')).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/apps/api/src/invoices/invoices.service.spec.ts
+++ b/apps/api/src/invoices/invoices.service.spec.ts
@@ -1,5 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { InternalServerErrorException, NotFoundException } from '@nestjs/common';
+import {
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InvoicesService } from './invoices.service';
@@ -135,7 +138,9 @@ describe('InvoicesService', () => {
 
       const result = await service.findAll('user-1');
 
-      expect(mockInvoicesRepository.findAllByUserId).toHaveBeenCalledWith('user-1');
+      expect(mockInvoicesRepository.findAllByUserId).toHaveBeenCalledWith(
+        'user-1',
+      );
       expect(result).toBe(invoices);
     });
   });
@@ -149,18 +154,24 @@ describe('InvoicesService', () => {
 
     it('should return the invoice with transactions when found', async () => {
       const invoice = { id: 'inv-1', userId: 'user-1', transactions: [] };
-      mockInvoicesRepository.findByIdWithTransactions.mockResolvedValue(invoice);
+      mockInvoicesRepository.findByIdWithTransactions.mockResolvedValue(
+        invoice,
+      );
 
       const result = await service.findById('inv-1', 'user-1');
 
-      expect(mockInvoicesRepository.findByIdWithTransactions).toHaveBeenCalledWith('inv-1', 'user-1');
+      expect(
+        mockInvoicesRepository.findByIdWithTransactions,
+      ).toHaveBeenCalledWith('inv-1', 'user-1');
       expect(result).toBe(invoice);
     });
 
     it('should throw NotFoundException when invoice is not found', async () => {
       mockInvoicesRepository.findByIdWithTransactions.mockResolvedValue(null);
 
-      await expect(service.findById('inv-1', 'user-1')).rejects.toThrow(NotFoundException);
+      await expect(service.findById('inv-1', 'user-1')).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 });

--- a/apps/api/src/invoices/invoices.service.ts
+++ b/apps/api/src/invoices/invoices.service.ts
@@ -1,9 +1,10 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { Invoice } from '@prisma/client';
 import { StorageService } from '../storage/storage.service';
 import { INVOICES_BUCKET } from '../storage/storage.constants';
-import { InvoicesRepository } from './invoices.repository';
+import { InvoicesRepository, InvoiceWithTransactions } from './invoices.repository';
 import { InvoiceCreatedEvent } from './events/invoice-created.event';
 
 @Injectable()
@@ -43,5 +44,15 @@ export class InvoicesService {
     );
 
     return { invoiceId: invoice.id };
+  }
+
+  async findAll(userId: string): Promise<Invoice[]> {
+    return this.invoicesRepository.findAllByUserId(userId);
+  }
+
+  async findById(id: string, userId: string): Promise<InvoiceWithTransactions> {
+    const invoice = await this.invoicesRepository.findByIdWithTransactions(id, userId);
+    if (!invoice) throw new NotFoundException(`Invoice ${id} not found`);
+    return invoice;
   }
 }

--- a/apps/api/src/invoices/invoices.service.ts
+++ b/apps/api/src/invoices/invoices.service.ts
@@ -4,7 +4,10 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Invoice } from '@prisma/client';
 import { StorageService } from '../storage/storage.service';
 import { INVOICES_BUCKET } from '../storage/storage.constants';
-import { InvoicesRepository, InvoiceWithTransactions } from './invoices.repository';
+import {
+  InvoicesRepository,
+  InvoiceWithTransactions,
+} from './invoices.repository';
 import { InvoiceCreatedEvent } from './events/invoice-created.event';
 
 @Injectable()
@@ -51,7 +54,10 @@ export class InvoicesService {
   }
 
   async findById(id: string, userId: string): Promise<InvoiceWithTransactions> {
-    const invoice = await this.invoicesRepository.findByIdWithTransactions(id, userId);
+    const invoice = await this.invoicesRepository.findByIdWithTransactions(
+      id,
+      userId,
+    );
     if (!invoice) throw new NotFoundException(`Invoice ${id} not found`);
     return invoice;
   }

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -3,10 +3,8 @@ import {
   Controller,
   Headers,
   Post,
-  RawBodyRequest,
   Req,
 } from '@nestjs/common';
-import { Request } from 'express';
 import { Public } from '../auth/public.decorator';
 import { UsersService } from './users.service';
 import { WebhookVerifier } from './webhook-verifier';
@@ -26,7 +24,7 @@ export class UsersController {
   @Public()
   @Post('clerk')
   async handleWebhook(
-    @Req() req: RawBodyRequest<Request>,
+    @Req() req: { rawBody?: Buffer },
     @Headers() headers: Record<string, string>,
   ): Promise<void> {
     let event: ClerkWebhookEvent;


### PR DESCRIPTION
## Summary

- `GET /invoices` — lista todas as invoices do usuário autenticado, ordenadas por data de criação (mais recente primeiro)
- `GET /invoices/:id` — detalhe de uma invoice com todas as transactions
- Invoice de outro usuário retorna 404 (não vaza existência)
- Responses serializadas via DTOs — campos internos (`storagePath`, `userId`, `tx.id`) não são expostos

## DTOs

**GET /invoices** → `[{ id, filename, status, createdAt }]`

**GET /invoices/:id** → `{ id, filename, status, createdAt, transactions: [{ date, description, amount, type, category }] }`

## Test plan

- [ ] 53/53 testes passando
- [ ] `GET /invoices` com token válido → retorna lista
- [ ] `GET /invoices/:id` com invoice própria → retorna detalhe com transactions
- [ ] `GET /invoices/:id` com invoice de outro user → 404
- [ ] `GET /invoices/:id` com id inexistente → 404
- [ ] `GET /invoices` sem token → 401

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)