### PR TITLE
feat: add CategorizationModule with MerchantRule lookup and batch classification

### DIFF
--- a/apps/api/prisma/migrations/20260517193937_add_categorization_fields/migration.sql
+++ b/apps/api/prisma/migrations/20260517193937_add_categorization_fields/migration.sql
@@ -1,0 +1,21 @@
+-- AlterTable
+ALTER TABLE "Transaction" ADD COLUMN     "confidence" DOUBLE PRECISION,
+ADD COLUMN     "needsReview" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "subcategory" TEXT;
+
+-- CreateTable
+CREATE TABLE "MerchantRule" (
+    "id" TEXT NOT NULL,
+    "pattern" TEXT NOT NULL,
+    "category" TEXT NOT NULL,
+    "subcategory" TEXT,
+    "confidence" DOUBLE PRECISION NOT NULL,
+    "voteCount" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MerchantRule_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MerchantRule_pattern_key" ON "MerchantRule"("pattern");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -31,10 +31,24 @@ model Transaction {
   invoice     Invoice         @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
   date        DateTime
   description String
-  amount      Decimal  @db.Decimal(10, 2)
+  amount      Decimal         @db.Decimal(10, 2)
   type        TransactionType
   category    String?
+  subcategory String?
+  confidence  Float?
+  needsReview Boolean         @default(false)
   createdAt   DateTime        @default(now())
+}
+
+model MerchantRule {
+  id          String   @id @default(cuid())
+  pattern     String   @unique
+  category    String
+  subcategory String?
+  confidence  Float
+  voteCount   Int      @default(1)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 }
 
 enum InvoiceStatus {

--- a/apps/api/src/categorization/categories.ts
+++ b/apps/api/src/categorization/categories.ts
@@ -1,0 +1,49 @@
+export const CATEGORIES: Record<string, readonly string[]> = {
+  Alimentação: [
+    'Delivery',
+    'Restaurante',
+    'Supermercado',
+    'Padaria / Café',
+    'Lanchonete / Fast food',
+  ],
+  Transporte: [
+    'Uber / 99 / Taxi',
+    'Combustível',
+    'Estacionamento',
+    'Transporte público',
+    'Pedágio',
+  ],
+  Moradia: [
+    'Aluguel',
+    'Condomínio',
+    'Água / Luz / Gás',
+    'Internet / TV',
+    'Manutenção',
+  ],
+  Saúde: [
+    'Farmácia',
+    'Consulta médica',
+    'Exame / Laboratório',
+    'Plano de saúde',
+    'Academia',
+  ],
+  Entretenimento: ['Cinema / Teatro', 'Jogos', 'Bares / Baladas'],
+  Assinaturas: ['Streaming', 'Música', 'Software', 'Outros serviços'],
+  Compras: [
+    'Roupas / Calçados',
+    'Eletrônicos',
+    'Casa / Decoração',
+    'Marketplace',
+    'Cosméticos / Beleza',
+  ],
+  Educação: ['Faculdade / Curso', 'Livros', 'Assinatura de conteúdo'],
+  Viagem: ['Passagem', 'Hospedagem', 'Aluguel de carro', 'Passeios / Atrações'],
+  Finanças: ['Fatura / Boleto', 'Investimento', 'Seguro', 'Tarifa bancária'],
+  Outros: [],
+};
+
+export const VALID_CATEGORIES = new Set(Object.keys(CATEGORIES));
+
+export const CONFIDENCE_THRESHOLD = 0.7;
+export const MERCHANT_RULE_MIN_CONFIDENCE = 0.9;
+export const FALLBACK_CATEGORY = 'Outros';

--- a/apps/api/src/categorization/categories.ts
+++ b/apps/api/src/categorization/categories.ts
@@ -39,6 +39,7 @@ export const CATEGORIES: Record<string, readonly string[]> = {
   Educação: ['Faculdade / Curso', 'Livros', 'Assinatura de conteúdo'],
   Viagem: ['Passagem', 'Hospedagem', 'Aluguel de carro', 'Passeios / Atrações'],
   Finanças: ['Fatura / Boleto', 'Investimento', 'Seguro', 'Tarifa bancária'],
+  Pets: ['Veterinário', 'Ração / Petisco', 'Pet shop / Banho e tosa', 'Medicamento / Vacina'],
   Outros: [],
 };
 

--- a/apps/api/src/categorization/categorization.module.ts
+++ b/apps/api/src/categorization/categorization.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CategorizationService } from './categorization.service';
+import { MerchantRuleRepository } from './merchant-rule.repository';
+
+@Module({
+  providers: [CategorizationService, MerchantRuleRepository],
+  exports: [CategorizationService],
+})
+export class CategorizationModule {}

--- a/apps/api/src/categorization/categorization.service.spec.ts
+++ b/apps/api/src/categorization/categorization.service.spec.ts
@@ -1,0 +1,215 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategorizationService } from './categorization.service';
+import { MerchantRuleRepository } from './merchant-rule.repository';
+
+const mockMerchantRuleRepository = {
+  findByPattern: jest.fn(),
+  findByPatterns: jest.fn(),
+};
+
+describe('CategorizationService', () => {
+  let service: CategorizationService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CategorizationService,
+        {
+          provide: MerchantRuleRepository,
+          useValue: mockMerchantRuleRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<CategorizationService>(CategorizationService);
+    jest.resetAllMocks();
+  });
+
+  describe('classify', () => {
+    it('should return category and subcategory as-is when valid and confidence >= 0.7', async () => {
+      mockMerchantRuleRepository.findByPattern.mockResolvedValue(null);
+
+      const result = await service.classify(
+        'IFOOD*REST X',
+        'Alimentação',
+        'Delivery',
+        0.95,
+      );
+
+      expect(result).toEqual({
+        category: 'Alimentação',
+        subcategory: 'Delivery',
+        confidence: 0.95,
+        needsReview: false,
+      });
+    });
+
+    it('should return Outros and needsReview when confidence < 0.7', async () => {
+      mockMerchantRuleRepository.findByPattern.mockResolvedValue(null);
+
+      const result = await service.classify(
+        'PG*ABC123',
+        'Alimentação',
+        'Restaurante',
+        0.5,
+      );
+
+      expect(result).toEqual({
+        category: 'Outros',
+        subcategory: null,
+        confidence: 0.5,
+        needsReview: true,
+      });
+    });
+
+    it('should return Outros and needsReview when category is not in the valid list', async () => {
+      mockMerchantRuleRepository.findByPattern.mockResolvedValue(null);
+
+      const result = await service.classify(
+        'LOJA X',
+        'Comida',
+        'Restaurante',
+        0.9,
+      );
+
+      expect(result).toEqual({
+        category: 'Outros',
+        subcategory: null,
+        confidence: 0.9,
+        needsReview: true,
+      });
+    });
+
+    it('should keep category but nullify subcategory when subcategory is invalid', async () => {
+      mockMerchantRuleRepository.findByPattern.mockResolvedValue(null);
+
+      const result = await service.classify('UBER', 'Transporte', 'Avião', 0.8);
+
+      expect(result).toEqual({
+        category: 'Transporte',
+        subcategory: null,
+        confidence: 0.8,
+        needsReview: true,
+      });
+    });
+
+    it('should always set needsReview when category is Outros', async () => {
+      mockMerchantRuleRepository.findByPattern.mockResolvedValue(null);
+
+      const result = await service.classify(
+        'JOAO SILVA ME',
+        'Outros',
+        null,
+        0.8,
+      );
+
+      expect(result).toEqual({
+        category: 'Outros',
+        subcategory: null,
+        confidence: 0.8,
+        needsReview: true,
+      });
+    });
+
+    it('should use MerchantRule when found with confidence >= 0.9', async () => {
+      mockMerchantRuleRepository.findByPattern.mockResolvedValue({
+        category: 'Alimentação',
+        subcategory: 'Supermercado',
+        confidence: 0.95,
+      });
+
+      const result = await service.classify(
+        'MERCADAO LTDA',
+        'Outros',
+        null,
+        0.3,
+      );
+
+      expect(result).toEqual({
+        category: 'Alimentação',
+        subcategory: 'Supermercado',
+        confidence: 0.95,
+        needsReview: false,
+      });
+    });
+
+    it('should ignore MerchantRule when its confidence < 0.9 and use Claude result', async () => {
+      mockMerchantRuleRepository.findByPattern.mockResolvedValue({
+        category: 'Alimentação',
+        subcategory: 'Supermercado',
+        confidence: 0.7,
+      });
+
+      const result = await service.classify(
+        'LOJA X',
+        'Compras',
+        'Marketplace',
+        0.85,
+      );
+
+      expect(result).toEqual({
+        category: 'Compras',
+        subcategory: 'Marketplace',
+        confidence: 0.85,
+        needsReview: false,
+      });
+    });
+  });
+
+  describe('classifyMany', () => {
+    it('should issue a single batch query and classify all transactions', async () => {
+      mockMerchantRuleRepository.findByPatterns.mockResolvedValue([
+        {
+          pattern: 'IFOOD',
+          category: 'Alimentação',
+          subcategory: 'Delivery',
+          confidence: 0.95,
+        },
+      ]);
+
+      const inputs = [
+        {
+          description: 'IFOOD',
+          category: 'Outros',
+          subcategory: null,
+          confidence: 0.4,
+        },
+        {
+          description: 'NETFLIX',
+          category: 'Assinaturas',
+          subcategory: 'Streaming',
+          confidence: 0.98,
+        },
+      ];
+
+      const result = await service.classifyMany(inputs);
+
+      expect(mockMerchantRuleRepository.findByPatterns).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(mockMerchantRuleRepository.findByPatterns).toHaveBeenCalledWith([
+        'IFOOD',
+        'NETFLIX',
+      ]);
+      expect(result[0]).toEqual({
+        category: 'Alimentação',
+        subcategory: 'Delivery',
+        confidence: 0.95,
+        needsReview: false,
+      });
+      expect(result[1]).toEqual({
+        category: 'Assinaturas',
+        subcategory: 'Streaming',
+        confidence: 0.98,
+        needsReview: false,
+      });
+    });
+
+    it('should return empty array without querying when input is empty', async () => {
+      const result = await service.classifyMany([]);
+
+      expect(mockMerchantRuleRepository.findByPatterns).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/apps/api/src/categorization/categorization.service.ts
+++ b/apps/api/src/categorization/categorization.service.ts
@@ -1,0 +1,112 @@
+import { Injectable } from '@nestjs/common';
+import {
+  CATEGORIES,
+  CONFIDENCE_THRESHOLD,
+  FALLBACK_CATEGORY,
+  MERCHANT_RULE_MIN_CONFIDENCE,
+  VALID_CATEGORIES,
+} from './categories';
+import { MerchantRuleRepository } from './merchant-rule.repository';
+
+export interface ClassificationResult {
+  category: string;
+  subcategory: string | null;
+  confidence: number;
+  needsReview: boolean;
+}
+
+@Injectable()
+export class CategorizationService {
+  constructor(
+    private readonly merchantRuleRepository: MerchantRuleRepository,
+  ) {}
+
+  async classify(
+    description: string,
+    claudeCategory: string | null,
+    claudeSubcategory: string | null,
+    claudeConfidence: number,
+  ): Promise<ClassificationResult> {
+    const rule = await this.merchantRuleRepository.findByPattern(description);
+    if (rule && rule.confidence >= MERCHANT_RULE_MIN_CONFIDENCE) {
+      return {
+        category: rule.category,
+        subcategory: rule.subcategory,
+        confidence: rule.confidence,
+        needsReview: false,
+      };
+    }
+
+    return this.applyThreshold(
+      claudeCategory,
+      claudeSubcategory,
+      claudeConfidence,
+    );
+  }
+
+  async classifyMany(
+    transactions: Array<{
+      description: string;
+      category: string;
+      subcategory: string | null;
+      confidence: number;
+    }>,
+  ): Promise<ClassificationResult[]> {
+    if (transactions.length === 0) return [];
+
+    const rules = await this.merchantRuleRepository.findByPatterns(
+      transactions.map((t) => t.description),
+    );
+    const ruleMap = new Map(rules.map((r) => [r.pattern, r]));
+
+    return transactions.map((t) => {
+      const rule = ruleMap.get(t.description);
+      if (rule && rule.confidence >= MERCHANT_RULE_MIN_CONFIDENCE) {
+        return {
+          category: rule.category,
+          subcategory: rule.subcategory,
+          confidence: rule.confidence,
+          needsReview: false,
+        };
+      }
+      return this.applyThreshold(t.category, t.subcategory, t.confidence);
+    });
+  }
+
+  private applyThreshold(
+    category: string | null,
+    subcategory: string | null,
+    confidence: number,
+  ): ClassificationResult {
+    if (
+      !category ||
+      !VALID_CATEGORIES.has(category) ||
+      confidence < CONFIDENCE_THRESHOLD
+    ) {
+      return {
+        category: FALLBACK_CATEGORY,
+        subcategory: null,
+        confidence,
+        needsReview: true,
+      };
+    }
+
+    if (category === FALLBACK_CATEGORY) {
+      return {
+        category: FALLBACK_CATEGORY,
+        subcategory: null,
+        confidence,
+        needsReview: true,
+      };
+    }
+
+    const validSubcategories = CATEGORIES[category];
+    const validSubcategory =
+      subcategory && validSubcategories.includes(subcategory)
+        ? subcategory
+        : null;
+    const needsReview = validSubcategory === null && subcategory !== null;
+
+    return { category, subcategory: validSubcategory, confidence, needsReview };
+  }
+}

--- a/apps/api/src/categorization/merchant-rule.repository.spec.ts
+++ b/apps/api/src/categorization/merchant-rule.repository.spec.ts
@@ -1,0 +1,120 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MerchantRuleRepository } from './merchant-rule.repository';
+import { PrismaService } from '../prisma/prisma.service';
+
+const mockPrisma = {
+  merchantRule: {
+    findUnique: jest.fn(),
+    findMany: jest.fn(),
+    upsert: jest.fn(),
+  },
+};
+
+describe('MerchantRuleRepository', () => {
+  let repository: MerchantRuleRepository;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MerchantRuleRepository,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    repository = module.get<MerchantRuleRepository>(MerchantRuleRepository);
+    jest.resetAllMocks();
+  });
+
+  describe('findByPattern', () => {
+    it('should return the rule when found', async () => {
+      const rule = {
+        pattern: 'IFOOD',
+        category: 'Alimentação',
+        subcategory: 'Delivery',
+        confidence: 0.95,
+        voteCount: 3,
+      };
+      mockPrisma.merchantRule.findUnique.mockResolvedValue(rule);
+
+      const result = await repository.findByPattern('IFOOD');
+
+      expect(mockPrisma.merchantRule.findUnique).toHaveBeenCalledWith({
+        where: { pattern: 'IFOOD' },
+      });
+      expect(result).toBe(rule);
+    });
+
+    it('should return null when not found', async () => {
+      mockPrisma.merchantRule.findUnique.mockResolvedValue(null);
+
+      const result = await repository.findByPattern('UNKNOWN');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findByPatterns', () => {
+    it('should return rules matching the given patterns', async () => {
+      const rules = [
+        {
+          pattern: 'IFOOD',
+          category: 'Alimentação',
+          subcategory: 'Delivery',
+          confidence: 0.95,
+          voteCount: 1,
+        },
+      ];
+      mockPrisma.merchantRule.findMany.mockResolvedValue(rules);
+
+      const result = await repository.findByPatterns(['IFOOD', 'UBER']);
+
+      expect(mockPrisma.merchantRule.findMany).toHaveBeenCalledWith({
+        where: { pattern: { in: ['IFOOD', 'UBER'] } },
+      });
+      expect(result).toBe(rules);
+    });
+
+    it('should return empty array without querying when patterns list is empty', async () => {
+      const result = await repository.findByPatterns([]);
+
+      expect(mockPrisma.merchantRule.findMany).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('upsert', () => {
+    it('should create a new rule when pattern does not exist', async () => {
+      await repository.upsert('IFOOD', 'Alimentação', 'Delivery');
+
+      expect(mockPrisma.merchantRule.upsert).toHaveBeenCalledWith({
+        where: { pattern: 'IFOOD' },
+        create: {
+          pattern: 'IFOOD',
+          category: 'Alimentação',
+          subcategory: 'Delivery',
+          confidence: 1,
+          voteCount: 1,
+        },
+        update: {
+          category: 'Alimentação',
+          subcategory: 'Delivery',
+          voteCount: { increment: 1 },
+          confidence: 1,
+        },
+      });
+    });
+
+    it('should update existing rule incrementing voteCount', async () => {
+      await repository.upsert('UBER', 'Transporte', 'Uber / 99 / Taxi');
+
+      expect(mockPrisma.merchantRule.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { pattern: 'UBER' },
+          update: expect.objectContaining({
+            voteCount: { increment: 1 },
+          }) as object,
+        }) as object,
+      );
+    });
+  });
+});

--- a/apps/api/src/categorization/merchant-rule.repository.ts
+++ b/apps/api/src/categorization/merchant-rule.repository.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { MerchantRule } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class MerchantRuleRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findByPattern(pattern: string): Promise<MerchantRule | null> {
+    return this.prisma.merchantRule.findUnique({ where: { pattern } });
+  }
+
+  async findByPatterns(patterns: string[]): Promise<MerchantRule[]> {
+    if (patterns.length === 0) return [];
+    return this.prisma.merchantRule.findMany({
+      where: { pattern: { in: patterns } },
+    });
+  }
+
+  async upsert(
+    pattern: string,
+    category: string,
+    subcategory: string | null,
+  ): Promise<void> {
+    await this.prisma.merchantRule.upsert({
+      where: { pattern },
+      create: { pattern, category, subcategory, confidence: 1, voteCount: 1 },
+      update: {
+        category,
+        subcategory,
+        voteCount: { increment: 1 },
+        confidence: 1,
+      },
+    });
+  }
+}

--- a/apps/api/src/extraction/extraction.constants.ts
+++ b/apps/api/src/extraction/extraction.constants.ts
@@ -1,3 +1,2 @@
 export const ANTHROPIC_CLIENT = Symbol('ANTHROPIC_CLIENT');
 export const EXTRACTION_MODEL = 'claude-haiku-4-5-20251001';
-export const DEFAULT_CATEGORY = 'Other';

--- a/apps/api/src/extraction/extraction.service.spec.ts
+++ b/apps/api/src/extraction/extraction.service.spec.ts
@@ -43,12 +43,18 @@ describe('ExtractionService', () => {
           description: 'UBER *TRIP',
           amount: 60.0,
           type: 'debit',
+          category: 'Transporte',
+          subcategory: 'Uber / 99 / Taxi',
+          confidence: 0.95,
         },
         {
           date: '2025-04-15',
           description: 'NETFLIX',
           amount: 40.0,
           type: 'debit',
+          category: 'Assinaturas',
+          subcategory: 'Streaming',
+          confidence: 0.98,
         },
       ]),
     );
@@ -61,9 +67,11 @@ describe('ExtractionService', () => {
       description: 'UBER *TRIP',
       amount: 60.0,
       type: 'debit',
-      category: 'Other',
+      category: 'Transporte',
+      subcategory: 'Uber / 99 / Taxi',
+      confidence: 0.95,
     });
-    expect(result[1].category).toBe('Other');
+    expect(result[1].category).toBe('Assinaturas');
   });
 
   it('should throw when Claude returns text instead of tool_use', async () => {

--- a/apps/api/src/extraction/extraction.service.ts
+++ b/apps/api/src/extraction/extraction.service.ts
@@ -83,7 +83,7 @@ export class ExtractionService {
   async extract(pdf: Buffer): Promise<ExtractedTransaction[]> {
     const response = await this.client.messages.create({
       model: EXTRACTION_MODEL,
-      max_tokens: 4096,
+      max_tokens: 16000,
       tools: [EXTRACTION_TOOL],
       tool_choice: { type: 'tool', name: 'extract_transactions' },
       messages: [

--- a/apps/api/src/extraction/extraction.service.ts
+++ b/apps/api/src/extraction/extraction.service.ts
@@ -1,10 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import Anthropic from '@anthropic-ai/sdk';
-import {
-  ANTHROPIC_CLIENT,
-  DEFAULT_CATEGORY,
-  EXTRACTION_MODEL,
-} from './extraction.constants';
+import { ANTHROPIC_CLIENT, EXTRACTION_MODEL } from './extraction.constants';
 import { ExtractedTransaction } from './extraction.types';
 
 interface ClaudeExtractionResult {
@@ -14,6 +10,9 @@ interface ClaudeExtractionResult {
     description: string;
     amount: number;
     type: 'debit' | 'credit';
+    category: string;
+    subcategory: string | null;
+    confidence: number;
   }>;
 }
 
@@ -45,8 +44,31 @@ const EXTRACTION_TOOL: Anthropic.Tool = {
               description: 'Transaction amount (positive)',
             },
             type: { type: 'string', enum: ['debit', 'credit'] },
+            category: {
+              type: 'string',
+              description:
+                'Spending category. One of: Alimentação, Transporte, Moradia, Saúde, Entretenimento, Assinaturas, Compras, Educação, Viagem, Finanças, Outros',
+            },
+            subcategory: {
+              type: ['string', 'null'],
+              description:
+                'Subcategory within the chosen category, or null if unsure',
+            },
+            confidence: {
+              type: 'number',
+              description:
+                'Confidence score between 0 and 1 for the category assignment',
+            },
           },
-          required: ['date', 'description', 'amount', 'type'],
+          required: [
+            'date',
+            'description',
+            'amount',
+            'type',
+            'category',
+            'subcategory',
+            'confidence',
+          ],
         },
       },
     },
@@ -103,8 +125,13 @@ export class ExtractionService {
     this.validateSum(result);
 
     return result.transactions.map((t) => ({
-      ...t,
-      category: DEFAULT_CATEGORY,
+      date: t.date,
+      description: t.description,
+      amount: t.amount,
+      type: t.type,
+      category: t.category,
+      subcategory: t.subcategory,
+      confidence: t.confidence,
     }));
   }
 

--- a/apps/api/src/extraction/extraction.service.ts
+++ b/apps/api/src/extraction/extraction.service.ts
@@ -47,7 +47,7 @@ const EXTRACTION_TOOL: Anthropic.Tool = {
             category: {
               type: 'string',
               description:
-                'Spending category. One of: Alimentação, Transporte, Moradia, Saúde, Entretenimento, Assinaturas, Compras, Educação, Viagem, Finanças, Outros',
+                'Spending category. One of: Alimentação, Transporte, Moradia, Saúde, Entretenimento, Assinaturas, Compras, Educação, Viagem, Finanças, Pets, Outros',
             },
             subcategory: {
               type: ['string', 'null'],

--- a/apps/api/src/extraction/extraction.types.ts
+++ b/apps/api/src/extraction/extraction.types.ts
@@ -3,6 +3,7 @@ export interface ExtractedTransaction {
   description: string;
   amount: number;
   type: 'debit' | 'credit';
-  // MVP: always 'Other' — updated to full union when categorization module is implemented
   category: string;
+  subcategory: string | null;
+  confidence: number;
 }

--- a/apps/api/src/invoices/dto/invoice-detail-response.dto.ts
+++ b/apps/api/src/invoices/dto/invoice-detail-response.dto.ts
@@ -7,6 +7,9 @@ class TransactionDto {
   amount: number;
   type: string;
   category: string | null;
+  subcategory: string | null;
+  confidence: number | null;
+  needsReview: boolean;
 
   static from(t: Transaction): TransactionDto {
     return {
@@ -15,6 +18,9 @@ class TransactionDto {
       amount: Number(t.amount),
       type: t.type,
       category: t.category,
+      subcategory: t.subcategory,
+      confidence: t.confidence,
+      needsReview: t.needsReview,
     };
   }
 }

--- a/apps/api/src/transactions/transactions.listener.spec.ts
+++ b/apps/api/src/transactions/transactions.listener.spec.ts
@@ -5,6 +5,7 @@ import { TransactionsRepository } from './transactions.repository';
 import { InvoicesRepository } from '../invoices/invoices.repository';
 import { StorageService } from '../storage/storage.service';
 import { ExtractionService } from '../extraction/extraction.service';
+import { CategorizationService } from '../categorization/categorization.service';
 import { InvoiceCreatedEvent } from '../invoices/events/invoice-created.event';
 import { ExtractedTransaction } from '../extraction/extraction.types';
 
@@ -12,6 +13,7 @@ const mockTransactionsRepository = { createMany: jest.fn() };
 const mockInvoicesRepository = { updateStatus: jest.fn() };
 const mockStorageService = { download: jest.fn() };
 const mockExtractionService = { extract: jest.fn() };
+const mockCategorizationService = { classifyMany: jest.fn() };
 
 const event = new InvoiceCreatedEvent(
   'inv-1',
@@ -25,9 +27,17 @@ const extracted: ExtractedTransaction[] = [
     description: 'IFOOD',
     amount: 45.9,
     type: 'debit',
-    category: 'Other',
+    category: 'Alimentação',
+    subcategory: 'Delivery',
+    confidence: 0.95,
   },
 ];
+const classified = {
+  category: 'Alimentação',
+  subcategory: 'Delivery',
+  confidence: 0.95,
+  needsReview: false,
+};
 
 describe('TransactionsListener', () => {
   let listener: TransactionsListener;
@@ -43,6 +53,7 @@ describe('TransactionsListener', () => {
         { provide: InvoicesRepository, useValue: mockInvoicesRepository },
         { provide: StorageService, useValue: mockStorageService },
         { provide: ExtractionService, useValue: mockExtractionService },
+        { provide: CategorizationService, useValue: mockCategorizationService },
       ],
     }).compile();
 
@@ -50,9 +61,10 @@ describe('TransactionsListener', () => {
     jest.resetAllMocks();
   });
 
-  it('should download PDF, extract transactions, save them and mark invoice as DONE', async () => {
+  it('should download PDF, extract transactions, classify them, save them and mark invoice as DONE', async () => {
     mockStorageService.download.mockResolvedValue(pdfBuffer);
     mockExtractionService.extract.mockResolvedValue(extracted);
+    mockCategorizationService.classifyMany.mockResolvedValue([classified]);
 
     await listener.handleInvoiceCreated(event);
 
@@ -61,9 +73,12 @@ describe('TransactionsListener', () => {
       event.storagePath,
     );
     expect(mockExtractionService.extract).toHaveBeenCalledWith(pdfBuffer);
+    expect(mockCategorizationService.classifyMany).toHaveBeenCalledWith(
+      extracted,
+    );
     expect(mockTransactionsRepository.createMany).toHaveBeenCalledWith(
       'inv-1',
-      extracted,
+      [{ ...extracted[0], ...classified }],
     );
     expect(mockInvoicesRepository.updateStatus).toHaveBeenCalledWith(
       'inv-1',

--- a/apps/api/src/transactions/transactions.listener.ts
+++ b/apps/api/src/transactions/transactions.listener.ts
@@ -5,6 +5,7 @@ import { InvoiceCreatedEvent } from '../invoices/events/invoice-created.event';
 import { StorageService } from '../storage/storage.service';
 import { INVOICES_BUCKET } from '../storage/storage.constants';
 import { ExtractionService } from '../extraction/extraction.service';
+import { CategorizationService } from '../categorization/categorization.service';
 import { TransactionsRepository } from './transactions.repository';
 import { InvoicesRepository } from '../invoices/invoices.repository';
 
@@ -15,6 +16,7 @@ export class TransactionsListener {
   constructor(
     private readonly storageService: StorageService,
     private readonly extractionService: ExtractionService,
+    private readonly categorizationService: CategorizationService,
     private readonly transactionsRepository: TransactionsRepository,
     private readonly invoicesRepository: InvoicesRepository,
   ) {}
@@ -26,7 +28,13 @@ export class TransactionsListener {
         INVOICES_BUCKET,
         event.storagePath,
       );
-      const transactions = await this.extractionService.extract(pdf);
+      const extracted = await this.extractionService.extract(pdf);
+      const classifications =
+        await this.categorizationService.classifyMany(extracted);
+      const transactions = extracted.map((t, i) => ({
+        ...t,
+        ...classifications[i],
+      }));
       await this.transactionsRepository.createMany(
         event.invoiceId,
         transactions,

--- a/apps/api/src/transactions/transactions.module.ts
+++ b/apps/api/src/transactions/transactions.module.ts
@@ -4,9 +4,15 @@ import { TransactionsListener } from './transactions.listener';
 import { ExtractionModule } from '../extraction/extraction.module';
 import { StorageModule } from '../storage/storage.module';
 import { InvoicesModule } from '../invoices/invoices.module';
+import { CategorizationModule } from '../categorization/categorization.module';
 
 @Module({
-  imports: [ExtractionModule, StorageModule, InvoicesModule],
+  imports: [
+    ExtractionModule,
+    StorageModule,
+    InvoicesModule,
+    CategorizationModule,
+  ],
   providers: [TransactionsRepository, TransactionsListener],
 })
 export class TransactionsModule {}

--- a/apps/api/src/transactions/transactions.repository.spec.ts
+++ b/apps/api/src/transactions/transactions.repository.spec.ts
@@ -1,7 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { TransactionsRepository } from './transactions.repository';
+import {
+  TransactionsRepository,
+  TransactionCreateData,
+} from './transactions.repository';
 import { PrismaService } from '../prisma/prisma.service';
-import { ExtractedTransaction } from '../extraction/extraction.types';
 
 const mockPrisma = {
   transaction: {
@@ -10,20 +12,26 @@ const mockPrisma = {
   },
 };
 
-const transactions: ExtractedTransaction[] = [
+const transactions: TransactionCreateData[] = [
   {
     date: '2026-04-05',
     description: 'IFOOD',
     amount: 45.9,
     type: 'debit',
-    category: 'Other',
+    category: 'Alimentação',
+    subcategory: 'Delivery',
+    confidence: 0.95,
+    needsReview: false,
   },
   {
     date: '2026-04-07',
     description: 'UBER',
     amount: 18.5,
     type: 'debit',
-    category: 'Other',
+    category: 'Transporte',
+    subcategory: 'Uber / 99 / Taxi',
+    confidence: 0.9,
+    needsReview: false,
   },
 ];
 
@@ -56,6 +64,9 @@ describe('TransactionsRepository', () => {
           amount: t.amount,
           type: t.type.toUpperCase(),
           category: t.category,
+          subcategory: t.subcategory,
+          confidence: t.confidence,
+          needsReview: t.needsReview,
         })),
       });
     });

--- a/apps/api/src/transactions/transactions.repository.ts
+++ b/apps/api/src/transactions/transactions.repository.ts
@@ -1,7 +1,17 @@
 import { Injectable } from '@nestjs/common';
 import { Transaction, TransactionType } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
-import { ExtractedTransaction } from '../extraction/extraction.types';
+
+export interface TransactionCreateData {
+  date: string;
+  description: string;
+  amount: number;
+  type: 'debit' | 'credit';
+  category: string;
+  subcategory: string | null;
+  confidence: number;
+  needsReview: boolean;
+}
 
 @Injectable()
 export class TransactionsRepository {
@@ -9,7 +19,7 @@ export class TransactionsRepository {
 
   async createMany(
     invoiceId: string,
-    transactions: ExtractedTransaction[],
+    transactions: TransactionCreateData[],
   ): Promise<void> {
     if (transactions.length === 0) return;
 
@@ -21,6 +31,9 @@ export class TransactionsRepository {
         amount: t.amount,
         type: t.type.toUpperCase() as TransactionType,
         category: t.category,
+        subcategory: t.subcategory,
+        confidence: t.confidence,
+        needsReview: t.needsReview,
       })),
     });
   }


### PR DESCRIPTION
Closes #32

## Summary

- **CategorizationService**: classifies each transaction using a MerchantRule table lookup (single batch DB query per invoice) with Claude's category/subcategory/confidence as fallback; applies a 0.7 confidence threshold — low-confidence results fall back to `Outros` with `needsReview: true`
- **MerchantRuleRepository**: `findByPattern` (single) + `findByPatterns` (batch) + `upsert` for rule learning
- **Schema**: adds `subcategory`, `confidence`, `needsReview` columns to `Transaction`; new `MerchantRule` model
- **ExtractionService**: Claude tool schema now includes `category`, `subcategory`, `confidence` fields — classification happens in the same API call as extraction
- **TransactionsListener**: calls `classifyMany(extracted)` before saving — one batch DB query regardless of invoice size

## Test plan

- [ ] All 68 unit tests pass (`pnpm test` in `apps/api`)
- [ ] Typecheck and lint clean (`pnpm turbo typecheck && pnpm turbo lint`)
- [ ] Migration applied to DB (`prisma migrate deploy`)
- [ ] Upload a real invoice PDF and verify transactions are saved with category, subcategory, confidence, and needsReview populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)