### PR TITLE
feat: deletar fatura do usuário (hard delete)

### DIFF
--- a/apps/api/src/invoices/invoices.controller.spec.ts
+++ b/apps/api/src/invoices/invoices.controller.spec.ts
@@ -7,6 +7,7 @@ const mockInvoicesService = {
   create: jest.fn(),
   findAll: jest.fn(),
   findById: jest.fn(),
+  delete: jest.fn(),
 };
 
 describe('InvoicesController', () => {
@@ -114,6 +115,28 @@ describe('InvoicesController', () => {
       mockInvoicesService.findById.mockRejectedValue(new NotFoundException());
 
       await expect(controller.findOne('inv-1', 'user-1')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('DELETE /invoices/:id', () => {
+    it('should return undefined (204) when deletion succeeds', async () => {
+      mockInvoicesService.delete.mockResolvedValue(undefined);
+
+      const result = await controller.delete('inv-1', 'user-1');
+
+      expect(mockInvoicesService.delete).toHaveBeenCalledWith(
+        'inv-1',
+        'user-1',
+      );
+      expect(result).toBeUndefined();
+    });
+
+    it('should propagate NotFoundException when invoice is not found', async () => {
+      mockInvoicesService.delete.mockRejectedValue(new NotFoundException());
+
+      await expect(controller.delete('inv-1', 'user-1')).rejects.toThrow(
         NotFoundException,
       );
     });

--- a/apps/api/src/invoices/invoices.controller.ts
+++ b/apps/api/src/invoices/invoices.controller.ts
@@ -1,7 +1,10 @@
 import {
   Controller,
+  Delete,
   FileTypeValidator,
   Get,
+  HttpCode,
+  HttpStatus,
   MaxFileSizeValidator,
   Param,
   ParseFilePipe,
@@ -51,5 +54,14 @@ export class InvoicesController {
   ): Promise<InvoiceDetailResponseDto> {
     const invoice = await this.invoicesService.findById(id, userId);
     return InvoiceDetailResponseDto.from(invoice);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async delete(
+    @Param('id') id: string,
+    @CurrentUser() userId: string,
+  ): Promise<void> {
+    await this.invoicesService.delete(id, userId);
   }
 }

--- a/apps/api/src/invoices/invoices.repository.spec.ts
+++ b/apps/api/src/invoices/invoices.repository.spec.ts
@@ -7,6 +7,7 @@ const mockPrisma = {
     create: jest.fn(),
     findFirst: jest.fn(),
     findMany: jest.fn(),
+    delete: jest.fn(),
   },
 };
 
@@ -125,6 +126,18 @@ describe('InvoicesRepository', () => {
       );
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe('deleteById', () => {
+    it('should call prisma.invoice.delete with id and userId', async () => {
+      mockPrisma.invoice.delete.mockResolvedValue({});
+
+      await repository.deleteById('inv-1', 'user-1');
+
+      expect(mockPrisma.invoice.delete).toHaveBeenCalledWith({
+        where: { id: 'inv-1', userId: 'user-1' },
+      });
     });
   });
 });

--- a/apps/api/src/invoices/invoices.repository.ts
+++ b/apps/api/src/invoices/invoices.repository.ts
@@ -42,4 +42,8 @@ export class InvoicesRepository {
   async updateStatus(id: string, status: InvoiceStatus): Promise<void> {
     await this.prisma.invoice.update({ where: { id }, data: { status } });
   }
+
+  async deleteById(id: string, userId: string): Promise<void> {
+    await this.prisma.invoice.delete({ where: { id, userId } });
+  }
 }

--- a/apps/api/src/invoices/invoices.service.spec.ts
+++ b/apps/api/src/invoices/invoices.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import {
   InternalServerErrorException,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
@@ -10,11 +11,13 @@ import { InvoicesRepository } from './invoices.repository';
 import { StorageService } from '../storage/storage.service';
 import { InvoiceCreatedEvent } from './events/invoice-created.event';
 
-const mockStorageService = { upload: jest.fn() };
+const mockStorageService = { upload: jest.fn(), delete: jest.fn() };
 const mockInvoicesRepository = {
   create: jest.fn(),
+  findById: jest.fn(),
   findAllByUserId: jest.fn(),
   findByIdWithTransactions: jest.fn(),
+  deleteById: jest.fn(),
 };
 const mockEventEmitter = { emit: jest.fn() };
 
@@ -172,6 +175,69 @@ describe('InvoicesService', () => {
       await expect(service.findById('inv-1', 'user-1')).rejects.toThrow(
         NotFoundException,
       );
+    });
+  });
+
+  describe('delete', () => {
+    let service: InvoicesService;
+
+    beforeEach(async () => {
+      service = await createService('development');
+    });
+
+    it('should throw NotFoundException when invoice is not found', async () => {
+      mockInvoicesRepository.findById.mockResolvedValue(null);
+
+      await expect(service.delete('inv-1', 'user-1')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should call deleteById and storageService.delete on success', async () => {
+      mockInvoicesRepository.findById.mockResolvedValue({
+        id: 'inv-1',
+        storagePath: 'dev/user-1/fatura.pdf',
+      });
+      mockInvoicesRepository.deleteById.mockResolvedValue(undefined);
+      mockStorageService.delete.mockResolvedValue(undefined);
+
+      await service.delete('inv-1', 'user-1');
+
+      expect(mockInvoicesRepository.deleteById).toHaveBeenCalledWith(
+        'inv-1',
+        'user-1',
+      );
+      expect(mockStorageService.delete).toHaveBeenCalledWith(
+        'invoices',
+        'dev/user-1/fatura.pdf',
+      );
+    });
+
+    it('should not throw when storageService.delete fails', async () => {
+      mockInvoicesRepository.findById.mockResolvedValue({
+        id: 'inv-1',
+        storagePath: 'dev/user-1/fatura.pdf',
+      });
+      mockInvoicesRepository.deleteById.mockResolvedValue(undefined);
+      mockStorageService.delete.mockRejectedValue(new Error('storage error'));
+
+      await expect(service.delete('inv-1', 'user-1')).resolves.toBeUndefined();
+    });
+
+    it('should log error when storageService.delete fails', async () => {
+      mockInvoicesRepository.findById.mockResolvedValue({
+        id: 'inv-1',
+        storagePath: 'dev/user-1/fatura.pdf',
+      });
+      mockInvoicesRepository.deleteById.mockResolvedValue(undefined);
+      mockStorageService.delete.mockRejectedValue(new Error('storage error'));
+      const loggerSpy = jest
+        .spyOn(Logger.prototype, 'error')
+        .mockImplementation();
+
+      await service.delete('inv-1', 'user-1');
+
+      expect(loggerSpy).toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/invoices/invoices.service.ts
+++ b/apps/api/src/invoices/invoices.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Invoice } from '@prisma/client';
@@ -12,6 +12,7 @@ import { InvoiceCreatedEvent } from './events/invoice-created.event';
 
 @Injectable()
 export class InvoicesService {
+  private readonly logger = new Logger(InvoicesService.name);
   private readonly envPrefix: string;
 
   constructor(
@@ -60,5 +61,22 @@ export class InvoicesService {
     );
     if (!invoice) throw new NotFoundException(`Invoice ${id} not found`);
     return invoice;
+  }
+
+  async delete(id: string, userId: string): Promise<void> {
+    const invoice = await this.invoicesRepository.findById(id, userId);
+    if (!invoice) throw new NotFoundException(`Invoice ${id} not found`);
+
+    const { storagePath } = invoice;
+    await this.invoicesRepository.deleteById(id, userId);
+
+    try {
+      await this.storageService.delete(INVOICES_BUCKET, storagePath);
+    } catch (err) {
+      this.logger.error(
+        `Failed to delete storage file for invoice ${id}`,
+        err instanceof Error ? err.stack : String(err),
+      );
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Novo endpoint `DELETE /invoices/:id` que remove a fatura, suas transações (cascade Prisma) e o arquivo PDF no Supabase Storage
- Falha no Storage é logada mas não propaga erro — arquivo órfão tolerado no MVP
- Dupla camada de isolamento multi-tenant: `NotFoundException` no service + `userId` no WHERE do repository

## Changes

- `InvoicesController`: handler `DELETE :id` retornando 204
- `InvoicesService`: método `delete(id, userId)` — find → deleteById → storage delete
- `InvoicesRepository`: método `deleteById(id, userId)` — usa `findById` (sem JOIN de transactions)

## Test plan

- [ ] `DELETE /invoices/:id` com fatura válida retorna 204
- [ ] `DELETE /invoices/:id` com id inexistente retorna 404
- [ ] `DELETE /invoices/:id` com fatura de outro usuário retorna 404
- [ ] 74/74 testes passando, lint e typecheck limpos

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)