### PR TITLE
fix: habilitar RLS em todas as tabelas públicas

### DIFF
--- a/apps/api/prisma/migrations/20260519000000_enable_rls_public_tables/migration.sql
+++ b/apps/api/prisma/migrations/20260519000000_enable_rls_public_tables/migration.sql
@@ -1,0 +1,8 @@
+-- Enable RLS on all public tables to block direct PostgREST access.
+-- Prisma connects via DATABASE_URL with a role that has BYPASSRLS,
+-- so application behavior is unchanged.
+ALTER TABLE "User" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "Invoice" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "Transaction" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "MerchantRule" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "_prisma_migrations" ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Problema

O Supabase Security Advisor reportou 5 erros de **RLS Disabled in Public** nas tabelas `User`, `Invoice`, `Transaction`, `MerchantRule` e `_prisma_migrations`.

Sem RLS, qualquer pessoa com a `anon key` do Supabase consegue acessar diretamente essas tabelas via PostgREST, bypassando completamente a autenticação do NestJS.

## Solução

Habilitar RLS em todas as tabelas sem criar nenhuma policy — o comportamento padrão do PostgreSQL quando RLS está ativo sem policies é **negar tudo** para os roles `anon` e `authenticated` usados pelo PostgREST.

O Prisma **não é afetado**: a `DATABASE_URL` conecta com um role que tem `BYPASSRLS`, então toda a lógica da API continua funcionando normalmente.

## Test plan

- [ ] `prisma migrate deploy` executa sem erros
- [ ] API responde normalmente (health check, upload, listagem de faturas)
- [ ] Supabase Security Advisor não reporta mais os 5 erros após o deploy
🤖 Generated with [Claude Code](https://claude.com/claude-code)