### PR TITLE
fix: rodar prisma migrate deploy automaticamente no startup

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -47,4 +47,4 @@ EXPOSE 3333
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD wget -qO- http://localhost:3333/health || exit 1
 
-CMD ["node", "dist/main"]
+CMD ["sh", "-c", "pnpm exec prisma migrate deploy && node dist/main"]


### PR DESCRIPTION
## Problema

O `CMD` do Dockerfile só subia a app (`node dist/main`). As migrations precisavam ser rodadas manualmente no Railway, o que causou as migrations de RLS e `roles` não serem aplicadas após o merge.

## Solução

```dockerfile
CMD ["sh", "-c", "pnpm exec prisma migrate deploy && node dist/main"]
```

A cada deploy, o Railway roda as migrations pendentes antes de subir a app. Se não há migrations pendentes, o comando é no-op e a app sobe normalmente.

## Test plan

- [ ] Deploy no Railway aplica as migrations `enable_rls_public_tables` e `add_user_roles`
- [ ] API sobe normalmente após as migrations
- [ ] Supabase Security Advisor não reporta mais os 5 erros de RLS
- [ ] Query `UPDATE "User" SET roles = array_append(roles, 'mvp')` funciona

🤖 Generated with [Claude Code](https://claude.com/claude-code)