### PR TITLE
feat: editar transação — alias, categoria e MerchantRule pessoal

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -30,6 +30,8 @@
     "@nestjs/platform-express": "^11.0.1",
     "@prisma/client": "^6.19.3",
     "@supabase/supabase-js": "^2.105.4",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.15.1",
     "prisma": "^6.19.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",

--- a/apps/api/prisma/migrations/20260519000002_edit_transaction_merchant_rule/migration.sql
+++ b/apps/api/prisma/migrations/20260519000002_edit_transaction_merchant_rule/migration.sql
@@ -1,0 +1,26 @@
+-- Add alias to Transaction
+ALTER TABLE "Transaction" ADD COLUMN "alias" TEXT;
+
+-- Rebuild MerchantRule: drop old table and recreate with new schema
+DROP TABLE "MerchantRule";
+
+CREATE TYPE "MerchantRuleSource" AS ENUM ('USER_CORRECTION', 'LLM_INFERENCE');
+
+CREATE TABLE "MerchantRule" (
+  "id"          TEXT NOT NULL,
+  "userId"      TEXT NOT NULL,
+  "pattern"     TEXT NOT NULL,
+  "category"    TEXT NOT NULL,
+  "subcategory" TEXT,
+  "confidence"  DOUBLE PRECISION NOT NULL DEFAULT 1.0,
+  "source"      "MerchantRuleSource" NOT NULL DEFAULT 'USER_CORRECTION',
+  "createdAt"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"   TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "MerchantRule_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "MerchantRule_userId_pattern_key" ON "MerchantRule"("userId", "pattern");
+
+ALTER TABLE "MerchantRule" ADD CONSTRAINT "MerchantRule_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -9,10 +9,11 @@ datasource db {
 }
 
 model User {
-  id        String    @id
-  roles     String[]  @default([])
-  createdAt DateTime  @default(now())
-  invoices  Invoice[]
+  id            String         @id
+  roles         String[]       @default([])
+  createdAt     DateTime       @default(now())
+  invoices      Invoice[]
+  merchantRules MerchantRule[]
 }
 
 model Invoice {
@@ -32,6 +33,7 @@ model Transaction {
   invoice     Invoice         @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
   date        DateTime
   description String
+  alias       String?
   amount      Decimal         @db.Decimal(10, 2)
   type        TransactionType
   category    String?
@@ -42,14 +44,18 @@ model Transaction {
 }
 
 model MerchantRule {
-  id          String   @id @default(cuid())
-  pattern     String   @unique
+  id          String             @id @default(cuid())
+  userId      String
+  user        User               @relation(fields: [userId], references: [id], onDelete: Cascade)
+  pattern     String
   category    String
   subcategory String?
-  confidence  Float
-  voteCount   Int      @default(1)
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  confidence  Float              @default(1.0)
+  source      MerchantRuleSource @default(USER_CORRECTION)
+  createdAt   DateTime           @default(now())
+  updatedAt   DateTime           @updatedAt
+
+  @@unique([userId, pattern])
 }
 
 enum InvoiceStatus {
@@ -62,4 +68,9 @@ enum InvoiceStatus {
 enum TransactionType {
   DEBIT
   CREDIT
+}
+
+enum MerchantRuleSource {
+  USER_CORRECTION
+  LLM_INFERENCE
 }

--- a/apps/api/src/categorization/merchant-rule.repository.spec.ts
+++ b/apps/api/src/categorization/merchant-rule.repository.spec.ts
@@ -4,9 +4,8 @@ import { PrismaService } from '../prisma/prisma.service';
 
 const mockPrisma = {
   merchantRule: {
-    findUnique: jest.fn(),
+    findFirst: jest.fn(),
     findMany: jest.fn(),
-    upsert: jest.fn(),
   },
 };
 
@@ -32,20 +31,19 @@ describe('MerchantRuleRepository', () => {
         category: 'Alimentação',
         subcategory: 'Delivery',
         confidence: 0.95,
-        voteCount: 3,
       };
-      mockPrisma.merchantRule.findUnique.mockResolvedValue(rule);
+      mockPrisma.merchantRule.findFirst.mockResolvedValue(rule);
 
       const result = await repository.findByPattern('IFOOD');
 
-      expect(mockPrisma.merchantRule.findUnique).toHaveBeenCalledWith({
+      expect(mockPrisma.merchantRule.findFirst).toHaveBeenCalledWith({
         where: { pattern: 'IFOOD' },
       });
       expect(result).toBe(rule);
     });
 
     it('should return null when not found', async () => {
-      mockPrisma.merchantRule.findUnique.mockResolvedValue(null);
+      mockPrisma.merchantRule.findFirst.mockResolvedValue(null);
 
       const result = await repository.findByPattern('UNKNOWN');
 
@@ -61,7 +59,6 @@ describe('MerchantRuleRepository', () => {
           category: 'Alimentação',
           subcategory: 'Delivery',
           confidence: 0.95,
-          voteCount: 1,
         },
       ];
       mockPrisma.merchantRule.findMany.mockResolvedValue(rules);
@@ -79,42 +76,6 @@ describe('MerchantRuleRepository', () => {
 
       expect(mockPrisma.merchantRule.findMany).not.toHaveBeenCalled();
       expect(result).toEqual([]);
-    });
-  });
-
-  describe('upsert', () => {
-    it('should create a new rule when pattern does not exist', async () => {
-      await repository.upsert('IFOOD', 'Alimentação', 'Delivery');
-
-      expect(mockPrisma.merchantRule.upsert).toHaveBeenCalledWith({
-        where: { pattern: 'IFOOD' },
-        create: {
-          pattern: 'IFOOD',
-          category: 'Alimentação',
-          subcategory: 'Delivery',
-          confidence: 1,
-          voteCount: 1,
-        },
-        update: {
-          category: 'Alimentação',
-          subcategory: 'Delivery',
-          voteCount: { increment: 1 },
-          confidence: 1,
-        },
-      });
-    });
-
-    it('should update existing rule incrementing voteCount', async () => {
-      await repository.upsert('UBER', 'Transporte', 'Uber / 99 / Taxi');
-
-      expect(mockPrisma.merchantRule.upsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: { pattern: 'UBER' },
-          update: expect.objectContaining({
-            voteCount: { increment: 1 },
-          }) as object,
-        }) as object,
-      );
     });
   });
 });

--- a/apps/api/src/categorization/merchant-rule.repository.ts
+++ b/apps/api/src/categorization/merchant-rule.repository.ts
@@ -7,30 +7,13 @@ export class MerchantRuleRepository {
   constructor(private readonly prisma: PrismaService) {}
 
   async findByPattern(pattern: string): Promise<MerchantRule | null> {
-    return this.prisma.merchantRule.findUnique({ where: { pattern } });
+    return this.prisma.merchantRule.findFirst({ where: { pattern } });
   }
 
   async findByPatterns(patterns: string[]): Promise<MerchantRule[]> {
     if (patterns.length === 0) return [];
     return this.prisma.merchantRule.findMany({
       where: { pattern: { in: patterns } },
-    });
-  }
-
-  async upsert(
-    pattern: string,
-    category: string,
-    subcategory: string | null,
-  ): Promise<void> {
-    await this.prisma.merchantRule.upsert({
-      where: { pattern },
-      create: { pattern, category, subcategory, confidence: 1, voteCount: 1 },
-      update: {
-        category,
-        subcategory,
-        voteCount: { increment: 1 },
-        confidence: 1,
-      },
     });
   }
 }

--- a/apps/api/src/merchant-rules/merchant-rules.module.ts
+++ b/apps/api/src/merchant-rules/merchant-rules.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { MerchantRulesRepository } from './merchant-rules.repository';
+
+@Module({
+  providers: [MerchantRulesRepository],
+  exports: [MerchantRulesRepository],
+})
+export class MerchantRulesModule {}

--- a/apps/api/src/merchant-rules/merchant-rules.repository.spec.ts
+++ b/apps/api/src/merchant-rules/merchant-rules.repository.spec.ts
@@ -1,0 +1,77 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MerchantRuleSource } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { MerchantRulesRepository } from './merchant-rules.repository';
+
+const mockPrisma = {
+  merchantRule: {
+    upsert: jest.fn(),
+  },
+};
+
+describe('MerchantRulesRepository', () => {
+  let repository: MerchantRulesRepository;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MerchantRulesRepository,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    repository = module.get(MerchantRulesRepository);
+    jest.clearAllMocks();
+  });
+
+  describe('upsert', () => {
+    const input = {
+      userId: 'user-1',
+      pattern: 'UBER EATS',
+      category: 'Alimentação',
+      subcategory: 'Delivery',
+      confidence: 1.0,
+      source: MerchantRuleSource.USER_CORRECTION,
+    };
+
+    it('creates a new rule when none exists for (userId, pattern)', async () => {
+      mockPrisma.merchantRule.upsert.mockResolvedValue({ id: 'rule-1', ...input });
+
+      await repository.upsert(input);
+
+      expect(mockPrisma.merchantRule.upsert).toHaveBeenCalledWith({
+        where: { userId_pattern: { userId: input.userId, pattern: input.pattern } },
+        create: expect.objectContaining({
+          userId: input.userId,
+          pattern: input.pattern,
+          category: input.category,
+          subcategory: input.subcategory,
+          confidence: input.confidence,
+          source: input.source,
+        }),
+        update: expect.objectContaining({
+          category: input.category,
+          subcategory: input.subcategory,
+          confidence: input.confidence,
+          source: input.source,
+        }),
+      });
+    });
+
+    it('updates category, subcategory, confidence and source when rule already exists', async () => {
+      const updated = { ...input, category: 'Transporte', subcategory: null };
+      mockPrisma.merchantRule.upsert.mockResolvedValue({ id: 'rule-1', ...updated });
+
+      await repository.upsert(updated);
+
+      expect(mockPrisma.merchantRule.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          update: expect.objectContaining({
+            category: 'Transporte',
+            subcategory: null,
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/apps/api/src/merchant-rules/merchant-rules.repository.spec.ts
+++ b/apps/api/src/merchant-rules/merchant-rules.repository.spec.ts
@@ -35,12 +35,17 @@ describe('MerchantRulesRepository', () => {
     };
 
     it('creates a new rule when none exists for (userId, pattern)', async () => {
-      mockPrisma.merchantRule.upsert.mockResolvedValue({ id: 'rule-1', ...input });
+      mockPrisma.merchantRule.upsert.mockResolvedValue({
+        id: 'rule-1',
+        ...input,
+      });
 
       await repository.upsert(input);
 
       expect(mockPrisma.merchantRule.upsert).toHaveBeenCalledWith({
-        where: { userId_pattern: { userId: input.userId, pattern: input.pattern } },
+        where: {
+          userId_pattern: { userId: input.userId, pattern: input.pattern },
+        },
         create: expect.objectContaining({
           userId: input.userId,
           pattern: input.pattern,
@@ -48,19 +53,22 @@ describe('MerchantRulesRepository', () => {
           subcategory: input.subcategory,
           confidence: input.confidence,
           source: input.source,
-        }),
+        }) as unknown,
         update: expect.objectContaining({
           category: input.category,
           subcategory: input.subcategory,
           confidence: input.confidence,
           source: input.source,
-        }),
+        }) as unknown,
       });
     });
 
     it('updates category, subcategory, confidence and source when rule already exists', async () => {
       const updated = { ...input, category: 'Transporte', subcategory: null };
-      mockPrisma.merchantRule.upsert.mockResolvedValue({ id: 'rule-1', ...updated });
+      mockPrisma.merchantRule.upsert.mockResolvedValue({
+        id: 'rule-1',
+        ...updated,
+      });
 
       await repository.upsert(updated);
 
@@ -69,7 +77,7 @@ describe('MerchantRulesRepository', () => {
           update: expect.objectContaining({
             category: 'Transporte',
             subcategory: null,
-          }),
+          }) as unknown,
         }),
       );
     });

--- a/apps/api/src/merchant-rules/merchant-rules.repository.ts
+++ b/apps/api/src/merchant-rules/merchant-rules.repository.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { MerchantRuleSource } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+
+export interface MerchantRuleUpsertData {
+  userId: string;
+  pattern: string;
+  category: string;
+  subcategory: string | null | undefined;
+  confidence: number;
+  source: MerchantRuleSource;
+}
+
+@Injectable()
+export class MerchantRulesRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async upsert(data: MerchantRuleUpsertData): Promise<void> {
+    const fields = {
+      category: data.category,
+      subcategory: data.subcategory ?? null,
+      confidence: data.confidence,
+      source: data.source,
+    };
+
+    await this.prisma.merchantRule.upsert({
+      where: { userId_pattern: { userId: data.userId, pattern: data.pattern } },
+      create: { userId: data.userId, pattern: data.pattern, ...fields },
+      update: fields,
+    });
+  }
+}

--- a/apps/api/src/transactions/dto/update-transaction.dto.ts
+++ b/apps/api/src/transactions/dto/update-transaction.dto.ts
@@ -1,0 +1,15 @@
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class UpdateTransactionDto {
+  @IsOptional()
+  @IsString()
+  alias?: string;
+
+  @IsNotEmpty()
+  @IsString()
+  category: string;
+
+  @IsOptional()
+  @IsString()
+  subcategory?: string | null;
+}

--- a/apps/api/src/transactions/transactions.controller.spec.ts
+++ b/apps/api/src/transactions/transactions.controller.spec.ts
@@ -1,0 +1,46 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TransactionsController } from './transactions.controller';
+import { TransactionsService } from './transactions.service';
+
+const mockTransactionsService = {
+  update: jest.fn(),
+};
+
+describe('TransactionsController', () => {
+  let controller: TransactionsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TransactionsController],
+      providers: [
+        { provide: TransactionsService, useValue: mockTransactionsService },
+      ],
+    }).compile();
+
+    controller = module.get(TransactionsController);
+    jest.clearAllMocks();
+  });
+
+  describe('PUT /transactions/:id', () => {
+    const userId = 'user-1';
+    const transactionId = 'tx-1';
+    const dto = { alias: 'Uber Eats', category: 'Alimentação', subcategory: 'Delivery' };
+    const updatedTransaction = { id: transactionId, ...dto, needsReview: false };
+
+    it('returns 200 with the updated transaction', async () => {
+      mockTransactionsService.update.mockResolvedValue(updatedTransaction);
+
+      const result = await controller.update(transactionId, userId, dto);
+
+      expect(result).toEqual(updatedTransaction);
+      expect(mockTransactionsService.update).toHaveBeenCalledWith(transactionId, userId, dto);
+    });
+
+    it('propagates NotFoundException when transaction belongs to another user', async () => {
+      mockTransactionsService.update.mockRejectedValue(new NotFoundException());
+
+      await expect(controller.update(transactionId, userId, dto)).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/transactions/transactions.controller.ts
+++ b/apps/api/src/transactions/transactions.controller.ts
@@ -1,0 +1,19 @@
+import { Body, Controller, Param, Put } from '@nestjs/common';
+import { Transaction } from '@prisma/client';
+import { CurrentUser } from '../auth/current-user.decorator';
+import { UpdateTransactionDto } from './dto/update-transaction.dto';
+import { TransactionsService } from './transactions.service';
+
+@Controller('transactions')
+export class TransactionsController {
+  constructor(private readonly transactionsService: TransactionsService) {}
+
+  @Put(':id')
+  async update(
+    @Param('id') id: string,
+    @CurrentUser() userId: string,
+    @Body() dto: UpdateTransactionDto,
+  ): Promise<Transaction> {
+    return this.transactionsService.update(id, userId, dto);
+  }
+}

--- a/apps/api/src/transactions/transactions.module.ts
+++ b/apps/api/src/transactions/transactions.module.ts
@@ -1,10 +1,13 @@
 import { Module } from '@nestjs/common';
-import { TransactionsRepository } from './transactions.repository';
-import { TransactionsListener } from './transactions.listener';
+import { MerchantRulesModule } from '../merchant-rules/merchant-rules.module';
 import { ExtractionModule } from '../extraction/extraction.module';
 import { StorageModule } from '../storage/storage.module';
 import { InvoicesModule } from '../invoices/invoices.module';
 import { CategorizationModule } from '../categorization/categorization.module';
+import { TransactionsController } from './transactions.controller';
+import { TransactionsListener } from './transactions.listener';
+import { TransactionsRepository } from './transactions.repository';
+import { TransactionsService } from './transactions.service';
 
 @Module({
   imports: [
@@ -12,7 +15,9 @@ import { CategorizationModule } from '../categorization/categorization.module';
     StorageModule,
     InvoicesModule,
     CategorizationModule,
+    MerchantRulesModule,
   ],
-  providers: [TransactionsRepository, TransactionsListener],
+  controllers: [TransactionsController],
+  providers: [TransactionsRepository, TransactionsListener, TransactionsService],
 })
 export class TransactionsModule {}

--- a/apps/api/src/transactions/transactions.repository.ts
+++ b/apps/api/src/transactions/transactions.repository.ts
@@ -41,4 +41,17 @@ export class TransactionsRepository {
   async findByInvoice(invoiceId: string): Promise<Transaction[]> {
     return this.prisma.transaction.findMany({ where: { invoiceId } });
   }
+
+  async findByIdAndUserId(id: string, userId: string): Promise<Transaction | null> {
+    return this.prisma.transaction.findFirst({
+      where: { id, invoice: { userId } },
+    });
+  }
+
+  async update(
+    id: string,
+    data: { alias?: string; category?: string; subcategory?: string | null; needsReview?: boolean },
+  ): Promise<Transaction> {
+    return this.prisma.transaction.update({ where: { id }, data });
+  }
 }

--- a/apps/api/src/transactions/transactions.service.spec.ts
+++ b/apps/api/src/transactions/transactions.service.spec.ts
@@ -1,0 +1,113 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { MerchantRuleSource } from '@prisma/client';
+import { MerchantRulesRepository } from '../merchant-rules/merchant-rules.repository';
+import { UpdateTransactionDto } from './dto/update-transaction.dto';
+import { TransactionsRepository } from './transactions.repository';
+import { TransactionsService } from './transactions.service';
+
+const mockTransactionsRepository = {
+  findByIdAndUserId: jest.fn(),
+  update: jest.fn(),
+};
+
+const mockMerchantRulesRepository = {
+  upsert: jest.fn(),
+};
+
+describe('TransactionsService', () => {
+  let service: TransactionsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TransactionsService,
+        { provide: TransactionsRepository, useValue: mockTransactionsRepository },
+        { provide: MerchantRulesRepository, useValue: mockMerchantRulesRepository },
+      ],
+    }).compile();
+
+    service = module.get(TransactionsService);
+    jest.clearAllMocks();
+  });
+
+  describe('update', () => {
+    const userId = 'user-1';
+    const transactionId = 'tx-1';
+    const existingTransaction = {
+      id: transactionId,
+      description: 'UBER EATS',
+      alias: null,
+      category: 'Outros',
+      subcategory: null,
+      needsReview: true,
+    };
+    const dto: UpdateTransactionDto = {
+      alias: 'Uber Eats',
+      category: 'Alimentação',
+      subcategory: 'Delivery',
+    };
+
+    beforeEach(() => {
+      mockTransactionsRepository.findByIdAndUserId.mockResolvedValue(existingTransaction);
+      mockTransactionsRepository.update.mockResolvedValue({ ...existingTransaction, ...dto, needsReview: false });
+    });
+
+    it('updates alias, category and subcategory on the transaction', async () => {
+      await service.update(transactionId, userId, dto);
+
+      expect(mockTransactionsRepository.update).toHaveBeenCalledWith(
+        transactionId,
+        expect.objectContaining({
+          alias: dto.alias,
+          category: dto.category,
+          subcategory: dto.subcategory,
+        }),
+      );
+    });
+
+    it('clears needsReview when saving', async () => {
+      await service.update(transactionId, userId, dto);
+
+      expect(mockTransactionsRepository.update).toHaveBeenCalledWith(
+        transactionId,
+        expect.objectContaining({ needsReview: false }),
+      );
+    });
+
+    it('throws NotFoundException when transaction does not belong to userId', async () => {
+      mockTransactionsRepository.findByIdAndUserId.mockResolvedValue(null);
+
+      await expect(service.update(transactionId, userId, dto)).rejects.toThrow(NotFoundException);
+    });
+
+    it('upserts MerchantRule with userId, description as pattern, category, subcategory, confidence 1.0 and USER_CORRECTION source', async () => {
+      await service.update(transactionId, userId, dto);
+
+      expect(mockMerchantRulesRepository.upsert).toHaveBeenCalledWith({
+        userId,
+        pattern: existingTransaction.description,
+        category: dto.category,
+        subcategory: dto.subcategory,
+        confidence: 1.0,
+        source: MerchantRuleSource.USER_CORRECTION,
+      });
+    });
+
+    it('updates existing MerchantRule when same (userId, pattern) already exists', async () => {
+      const secondDto: UpdateTransactionDto = { category: 'Transporte', subcategory: null };
+      mockTransactionsRepository.update.mockResolvedValue({ ...existingTransaction, ...secondDto, needsReview: false });
+
+      await service.update(transactionId, userId, secondDto);
+
+      expect(mockMerchantRulesRepository.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId,
+          pattern: existingTransaction.description,
+          category: 'Transporte',
+          subcategory: null,
+        }),
+      );
+    });
+  });
+});

--- a/apps/api/src/transactions/transactions.service.ts
+++ b/apps/api/src/transactions/transactions.service.ts
@@ -1,0 +1,37 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { MerchantRuleSource, Transaction } from '@prisma/client';
+import { MerchantRulesRepository } from '../merchant-rules/merchant-rules.repository';
+import { UpdateTransactionDto } from './dto/update-transaction.dto';
+import { TransactionsRepository } from './transactions.repository';
+
+@Injectable()
+export class TransactionsService {
+  constructor(
+    private readonly transactionsRepository: TransactionsRepository,
+    private readonly merchantRulesRepository: MerchantRulesRepository,
+  ) {}
+
+  async update(id: string, userId: string, dto: UpdateTransactionDto): Promise<Transaction> {
+    const transaction = await this.transactionsRepository.findByIdAndUserId(id, userId);
+    if (!transaction) throw new NotFoundException(`Transaction ${id} not found`);
+
+    const [updated] = await Promise.all([
+      this.transactionsRepository.update(id, {
+        alias: dto.alias,
+        category: dto.category,
+        subcategory: dto.subcategory ?? null,
+        needsReview: false,
+      }),
+      this.merchantRulesRepository.upsert({
+        userId,
+        pattern: transaction.description,
+        category: dto.category,
+        subcategory: dto.subcategory ?? null,
+        confidence: 1.0,
+        source: MerchantRuleSource.USER_CORRECTION,
+      }),
+    ]);
+
+    return updated;
+  }
+}

--- a/apps/web/app/mvp/dashboard.tsx
+++ b/apps/web/app/mvp/dashboard.tsx
@@ -6,6 +6,21 @@ import { Cell, Pie, PieChart, Tooltip } from 'recharts';
 
 const API = process.env.NEXT_PUBLIC_API_URL;
 
+const CATEGORIES: Record<string, string[]> = {
+  Alimentação: ['Delivery', 'Restaurante', 'Supermercado', 'Padaria / Café', 'Lanchonete / Fast food'],
+  Transporte: ['Uber / 99 / Taxi', 'Combustível', 'Estacionamento', 'Transporte público', 'Pedágio'],
+  Moradia: ['Aluguel', 'Condomínio', 'Água / Luz / Gás', 'Internet / TV', 'Manutenção'],
+  Saúde: ['Farmácia', 'Consulta médica', 'Exame / Laboratório', 'Plano de saúde', 'Academia'],
+  Entretenimento: ['Cinema / Teatro', 'Jogos', 'Bares / Baladas'],
+  Assinaturas: ['Streaming', 'Música', 'Software', 'Outros serviços'],
+  Compras: ['Roupas / Calçados', 'Eletrônicos', 'Casa / Decoração', 'Marketplace', 'Cosméticos / Beleza'],
+  Educação: ['Faculdade / Curso', 'Livros', 'Assinatura de conteúdo'],
+  Viagem: ['Passagem', 'Hospedagem', 'Aluguel de carro', 'Passeios / Atrações'],
+  Finanças: ['Fatura / Boleto', 'Investimento', 'Seguro', 'Tarifa bancária'],
+  Pets: ['Veterinário', 'Ração / Petisco', 'Pet shop / Banho e tosa', 'Medicamento / Vacina'],
+  Outros: [],
+};
+
 const COLORS = [
   '#6366f1', '#f59e0b', '#10b981', '#ef4444', '#3b82f6',
   '#ec4899', '#8b5cf6', '#14b8a6', '#f97316', '#84cc16', '#06b6d4',
@@ -23,11 +38,13 @@ type Transaction = {
   id: string;
   date: string;
   description: string;
+  alias: string | null;
   amount: string;
   type: 'DEBIT' | 'CREDIT';
   category: string;
   subcategory: string | null;
 };
+
 
 type InvoiceDetail = Invoice & { transactions: Transaction[] };
 
@@ -44,6 +61,8 @@ export default function Dashboard() {
   const [filterCategory, setFilterCategory] = useState('');
   const [filterSubcategory, setFilterSubcategory] = useState('');
   const [filterType, setFilterType] = useState<'ALL' | 'DEBIT' | 'CREDIT'>('ALL');
+  const [editForm, setEditForm] = useState<{ transaction: Transaction; alias: string; category: string; subcategory: string } | null>(null);
+  const [saving, setSaving] = useState(false);
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const headers = useCallback(async () => {
@@ -89,6 +108,37 @@ export default function Dashboard() {
       }
     }, 3000);
   }, [fetchDetail, fetchInvoices]);
+
+  function openEdit(t: Transaction) {
+    setEditForm({ transaction: t, alias: t.alias ?? t.description, category: t.category, subcategory: t.subcategory ?? '' });
+  }
+
+  async function handleSaveEdit() {
+    if (!editForm) return;
+    setSaving(true);
+    try {
+      const h = await headers();
+      const res = await fetch(`${API}/transactions/${editForm.transaction.id}`, {
+        method: 'PUT',
+        headers: { ...h, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          alias: editForm.alias !== editForm.transaction.description ? editForm.alias : undefined,
+          category: editForm.category,
+          subcategory: editForm.subcategory || null,
+        }),
+      });
+      if (!res.ok) throw new Error('Erro ao salvar');
+      const updated: Transaction = await res.json();
+      setDetail((prev) =>
+        prev
+          ? { ...prev, transactions: prev.transactions.map((t) => (t.id === updated.id ? updated : t)) }
+          : prev,
+      );
+      setEditForm(null);
+    } finally {
+      setSaving(false);
+    }
+  }
 
   async function handleDelete() {
     if (!deleteTargetId) return;
@@ -290,11 +340,25 @@ export default function Dashboard() {
                 </thead>
                 <tbody>
                   {filteredTransactions.map((t) => (
-                    <tr key={t.id} className="border-b last:border-0 hover:bg-gray-50">
+                    <tr key={t.id} className="group border-b last:border-0 hover:bg-gray-50">
                       <td className="py-2 pr-4 text-gray-500 whitespace-nowrap">
                         {new Date(t.date).toLocaleDateString('pt-BR')}
                       </td>
-                      <td className="py-2 pr-4">{t.description}</td>
+                      <td className="py-2 pr-4">
+                        <span className="flex items-center gap-1">
+                          {t.alias ?? t.description}
+                          <button
+                            onClick={() => openEdit(t)}
+                            className="opacity-0 group-hover:opacity-100 text-gray-400 hover:text-indigo-600 transition-opacity"
+                            aria-label="Editar transação"
+                          >
+                            <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+                              <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
+                            </svg>
+                          </button>
+                        </span>
+                        {t.alias && <span className="block text-xs text-gray-400">{t.description}</span>}
+                      </td>
                       <td className="py-2 pr-4">
                         <span className="text-xs bg-indigo-100 text-indigo-700 px-2 py-0.5 rounded-full">{t.category}</span>
                         {t.subcategory && (
@@ -360,6 +424,64 @@ export default function Dashboard() {
       )}
       {detail?.status === 'FAILED' && (
         <p className="text-sm text-red-500 mt-4">Falha ao processar esta fatura.</p>
+      )}
+
+      {editForm && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+          <div className="bg-white rounded-xl border p-6 max-w-sm w-full mx-4 shadow-lg">
+            <h3 className="font-semibold text-gray-900 mb-4">Editar transação</h3>
+            <div className="space-y-3">
+              <div>
+                <label className="block text-xs text-gray-500 mb-1">Nome exibido</label>
+                <input
+                  type="text"
+                  value={editForm.alias}
+                  onChange={(e) => setEditForm((f) => f && { ...f, alias: e.target.value })}
+                  className="w-full text-sm border border-gray-300 rounded-lg px-3 py-2 text-gray-700"
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-500 mb-1">Categoria</label>
+                <select
+                  value={editForm.category}
+                  onChange={(e) => setEditForm((f) => f && { ...f, category: e.target.value, subcategory: '' })}
+                  className="w-full text-sm border border-gray-300 rounded-lg px-3 py-2 text-gray-700 bg-white"
+                >
+                  {Object.keys(CATEGORIES).map((c) => <option key={c} value={c}>{c}</option>)}
+                </select>
+              </div>
+              {CATEGORIES[editForm.category]?.length > 0 && (
+                <div>
+                  <label className="block text-xs text-gray-500 mb-1">Subcategoria</label>
+                  <select
+                    value={editForm.subcategory}
+                    onChange={(e) => setEditForm((f) => f && { ...f, subcategory: e.target.value })}
+                    className="w-full text-sm border border-gray-300 rounded-lg px-3 py-2 text-gray-700 bg-white"
+                  >
+                    <option value="">Nenhuma</option>
+                    {CATEGORIES[editForm.category].map((s) => <option key={s} value={s}>{s}</option>)}
+                  </select>
+                </div>
+              )}
+            </div>
+            <div className="flex justify-end gap-3 mt-6">
+              <button
+                onClick={() => setEditForm(null)}
+                disabled={saving}
+                className="px-4 py-2 text-sm rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50 transition disabled:opacity-50"
+              >
+                Cancelar
+              </button>
+              <button
+                onClick={handleSaveEdit}
+                disabled={saving}
+                className="px-4 py-2 text-sm rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 transition disabled:opacity-50"
+              >
+                {saving ? 'Salvando…' : 'Salvar'}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
 
       {deleteTargetId && (

--- a/apps/web/app/page.spec.tsx
+++ b/apps/web/app/page.spec.tsx
@@ -45,7 +45,7 @@ describe('HomePage', () => {
 
     render(await HomePage());
 
-    expect(screen.getByRole('link', { name: /sign in/i })).toHaveAttribute('href', '/sign-in');
+    expect(screen.getByRole('link', { name: /entrar/i })).toHaveAttribute('href', '/sign-in');
   });
 
   it('renders sign-up link when not authenticated', async () => {
@@ -53,6 +53,6 @@ describe('HomePage', () => {
 
     render(await HomePage());
 
-    expect(screen.getByRole('link', { name: /sign up/i })).toHaveAttribute('href', '/sign-up');
+    expect(screen.getByRole('link', { name: /criar conta/i })).toHaveAttribute('href', '/sign-up');
   });
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@clerk/localizations": "^4.4.1",
     "@clerk/nextjs": "^7.1.0",
-    "next": "15.3.9",
+"next": "15.3.9",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "recharts": "^3.8.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,25 +22,31 @@ importers:
         version: 3.4.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@nestjs/common':
         specifier: ^11.0.1
-        version: 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/config':
         specifier: ^4.0.4
-        version: 4.0.4(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2)
+        version: 4.0.4(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2)
       '@nestjs/core':
         specifier: ^11.0.1
-        version: 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/event-emitter':
         specifier: ^3.1.0
-        version: 3.1.0(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)
+        version: 3.1.0(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)
       '@nestjs/platform-express':
         specifier: ^11.0.1
-        version: 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)
+        version: 11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)
       '@prisma/client':
         specifier: ^6.19.3
         version: 6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3)
       '@supabase/supabase-js':
         specifier: ^2.105.4
         version: 2.105.4
+      class-transformer:
+        specifier: ^0.5.1
+        version: 0.5.1
+      class-validator:
+        specifier: ^0.15.1
+        version: 0.15.1
       prisma:
         specifier: ^6.19.3
         version: 6.19.3(typescript@5.9.3)
@@ -68,7 +74,7 @@ importers:
         version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.0.1
-        version: 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(@nestjs/platform-express@11.1.19)
+        version: 11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(@nestjs/platform-express@11.1.19)
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.6
@@ -183,7 +189,7 @@ importers:
         version: 15.3.9(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3))
+        version: 30.3.0(@types/node@20.19.39)
       jest-environment-jsdom:
         specifier: ^30.3.0
         version: 30.3.0
@@ -192,7 +198,7 @@ importers:
         version: 4.2.2
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@20.19.39))(typescript@5.9.3)
       typescript:
         specifier: ^5
         version: 5.9.3
@@ -1588,6 +1594,9 @@ packages:
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
+  '@types/validator@13.15.10':
+    resolution: {integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==}
+
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
 
@@ -2138,6 +2147,12 @@ packages:
 
   cjs-module-lexer@2.2.0:
     resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
+
+  class-transformer@0.5.1:
+    resolution: {integrity: sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==}
+
+  class-validator@0.15.1:
+    resolution: {integrity: sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==}
 
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
@@ -3459,6 +3474,9 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  libphonenumber-js@1.13.2:
+    resolution: {integrity: sha512-S3kmBrptp3yRTm83NUcHy9g1vbwiWMzI8WvY22+koBJ6zkRteLnedBL2VX0MIAGwx2yiyxX4J85pceZyQ6ffgg==}
+
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
     engines: {node: '>= 12.0.0'}
@@ -4660,6 +4678,10 @@ packages:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
+  validator@13.15.35:
+    resolution: {integrity: sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==}
+    engines: {node: '>= 0.10'}
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -5505,41 +5527,6 @@ snapshots:
       jest-util: 30.3.0
       slash: 3.0.0
 
-  '@jest/core@30.3.0(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3))':
-    dependencies:
-      '@jest/console': 30.3.0
-      '@jest/pattern': 30.0.1
-      '@jest/reporters': 30.3.0
-      '@jest/test-result': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
-      '@types/node': 22.19.17
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      exit-x: 0.2.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@22.19.17)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3))
-      jest-haste-map: 30.3.0
-      jest-message-util: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-resolve-dependencies: 30.3.0
-      jest-runner: 30.3.0
-      jest-runtime: 30.3.0
-      jest-snapshot: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      jest-watcher: 30.3.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
   '@jest/core@30.3.0(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 30.3.0
@@ -5783,7 +5770,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+  '@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
       file-type: 21.3.4
       iterare: 1.2.1
@@ -5792,20 +5779,23 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
       uid: 2.0.2
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.15.1
     transitivePeerDependencies:
       - supports-color
 
-  '@nestjs/config@4.0.4(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2)':
+  '@nestjs/config@4.0.4(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2)':
     dependencies:
-      '@nestjs/common': 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       dotenv: 17.4.1
       dotenv-expand: 12.0.3
       lodash: 4.18.1
       rxjs: 7.8.2
 
-  '@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+  '@nestjs/core@11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
-      '@nestjs/common': 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nuxt/opencollective': 0.4.1
       fast-safe-stringify: 2.1.1
       iterare: 1.2.1
@@ -5815,18 +5805,18 @@ snapshots:
       tslib: 2.8.1
       uid: 2.0.2
     optionalDependencies:
-      '@nestjs/platform-express': 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)
+      '@nestjs/platform-express': 11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)
 
-  '@nestjs/event-emitter@3.1.0(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)':
+  '@nestjs/event-emitter@3.1.0(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)':
     dependencies:
-      '@nestjs/common': 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       eventemitter2: 6.4.9
 
-  '@nestjs/platform-express@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)':
+  '@nestjs/platform-express@11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)':
     dependencies:
-      '@nestjs/common': 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       cors: 2.8.6
       express: 5.2.1
       multer: 2.1.1
@@ -5846,13 +5836,13 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/testing@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(@nestjs/platform-express@11.1.19)':
+  '@nestjs/testing@11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(@nestjs/platform-express@11.1.19)':
     dependencies:
-      '@nestjs/common': 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       tslib: 2.8.1
     optionalDependencies:
-      '@nestjs/platform-express': 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)
+      '@nestjs/platform-express': 11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)
 
   '@next/env@15.3.9': {}
 
@@ -6323,6 +6313,8 @@ snapshots:
   '@types/tough-cookie@4.0.5': {}
 
   '@types/use-sync-external-store@0.0.6': {}
+
+  '@types/validator@13.15.10': {}
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -6931,6 +6923,14 @@ snapshots:
 
   cjs-module-lexer@2.2.0: {}
 
+  class-transformer@0.5.1: {}
+
+  class-validator@0.15.1:
+    dependencies:
+      '@types/validator': 13.15.10
+      libphonenumber-js: 1.13.2
+      validator: 13.15.35
+
   cli-cursor@3.1.0:
     dependencies:
       restore-cursor: 3.1.0
@@ -7335,8 +7335,8 @@ snapshots:
       '@typescript-eslint/parser': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.4(jiti@2.6.1))
@@ -7359,7 +7359,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -7370,22 +7370,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7396,7 +7396,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -8185,15 +8185,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.3.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3)):
+  jest-cli@30.3.0(@types/node@20.19.39):
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3))
+      jest-config: 30.3.0(@types/node@20.19.39)
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -8223,7 +8223,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.3.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3)):
+  jest-config@30.3.0(@types/node@20.19.39):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -8250,39 +8250,6 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.19.39
-      ts-node: 10.9.2(@types/node@20.19.39)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@30.3.0(@types/node@22.19.17)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.3.0
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-runner: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      parse-json: 5.2.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.19.17
-      ts-node: 10.9.2(@types/node@20.19.39)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -8550,12 +8517,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.3.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3)):
+  jest@30.3.0(@types/node@20.19.39):
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
       '@jest/types': 30.3.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3))
+      jest-cli: 30.3.0(@types/node@20.19.39)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -8672,6 +8639,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  libphonenumber-js@1.13.2: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -9725,12 +9694,12 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-jest@29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@20.19.39))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.3.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3))
+      jest: 30.3.0(@types/node@20.19.39)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -9774,25 +9743,6 @@ snapshots:
       source-map: 0.7.6
       typescript: 5.9.3
       webpack: 5.106.0
-
-  ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.39
-      acorn: 8.16.0
-      acorn-walk: 8.3.5
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 5.9.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
 
   ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3):
     dependencies:
@@ -9981,6 +9931,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
+
+  validator@13.15.35: {}
 
   vary@1.1.2: {}
 


### PR DESCRIPTION
## Summary

- `PUT /transactions/:id` permite editar alias, categoria e subcategoria de uma transação
- Cada edição faz upsert em `MerchantRule` pessoal por `(userId, pattern)` com `source: USER_CORRECTION` — base para aprendizado coletivo futuro
- `MerchantRule` redesenhada: por usuário, enum `MerchantRuleSource`, sem `voteCount` global
- `MerchantRulesModule` criado como módulo separado, exportável para `CategorizationModule` no futuro
- Frontend: ícone de lápis ao passar o mouse na linha abre modal (alias + categoria + subcategoria)
- Categorias do frontend sincronizadas com o backend (estavam dessincronizadas)
- Categorização: `findByPattern` migrado de `findUnique` → `findFirst` (pattern não é mais globalmente único)

## Test plan

- [ ] 87 testes passando
- [ ] Build web sem erros
- [ ] `PUT /transactions/:id` com transação válida retorna 200 e atualiza a linha no frontend
- [ ] `PUT /transactions/:id` com transação de outro usuário retorna 404
- [ ] Modal abre com dados pré-preenchidos, salva e atualiza sem reload
- [ ] Alias exibido na tabela; descrição original aparece abaixo em cinza quando alias diferir

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)