### PR TITLE
feat: MonthPicker em português + edição por toque na linha

### DIFF
--- a/apps/web/app/mvp/dashboard.tsx
+++ b/apps/web/app/mvp/dashboard.tsx
@@ -451,11 +451,8 @@ export default function Dashboard() {
                         {t.alias && <span className="block text-xs text-gray-400">{t.description}</span>}
                       </td>
                       <td className="py-2 pr-4">
-                        <span className="inline-flex items-center gap-1 text-xs bg-indigo-100 text-indigo-700 px-2 py-0.5 rounded-full">
+                        <span className="text-xs bg-indigo-100 text-indigo-700 px-2 py-0.5 rounded-full">
                           {t.category}
-                          <svg xmlns="http://www.w3.org/2000/svg" className="w-3 h-3 opacity-40 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden>
-                            <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
-                          </svg>
                         </span>
                         {t.subcategory && (
                           <span className="ml-1 text-xs text-gray-500">{t.subcategory}</span>

--- a/apps/web/app/mvp/dashboard.tsx
+++ b/apps/web/app/mvp/dashboard.tsx
@@ -442,7 +442,7 @@ export default function Dashboard() {
                 </thead>
                 <tbody>
                   {filteredTransactions.map((t) => (
-                    <tr key={t.id} className="group border-b last:border-0 hover:bg-gray-50">
+                    <tr key={t.id} onClick={() => openEdit(t)} className="border-b last:border-0 hover:bg-gray-50 active:bg-indigo-50 cursor-pointer">
                       <td className="py-2 pr-4 text-gray-500 whitespace-nowrap">
                         {new Date(t.date).toLocaleDateString('pt-BR')}
                       </td>
@@ -451,16 +451,12 @@ export default function Dashboard() {
                         {t.alias && <span className="block text-xs text-gray-400">{t.description}</span>}
                       </td>
                       <td className="py-2 pr-4">
-                        <button
-                          onClick={() => openEdit(t)}
-                          aria-label="Editar categoria"
-                          className="group/cat inline-flex items-center gap-1 text-xs bg-indigo-100 text-indigo-700 px-2 py-0.5 rounded-full hover:bg-indigo-200 active:bg-indigo-300 transition"
-                        >
+                        <span className="inline-flex items-center gap-1 text-xs bg-indigo-100 text-indigo-700 px-2 py-0.5 rounded-full">
                           {t.category}
-                          <svg xmlns="http://www.w3.org/2000/svg" className="w-3 h-3 opacity-40 group-hover/cat:opacity-100 transition-opacity flex-shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden>
+                          <svg xmlns="http://www.w3.org/2000/svg" className="w-3 h-3 opacity-40 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden>
                             <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
                           </svg>
-                        </button>
+                        </span>
                         {t.subcategory && (
                           <span className="ml-1 text-xs text-gray-500">{t.subcategory}</span>
                         )}

--- a/apps/web/app/mvp/dashboard.tsx
+++ b/apps/web/app/mvp/dashboard.tsx
@@ -3,6 +3,7 @@
 import { useAuth } from '@clerk/nextjs';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { detectEncryptedPdf } from '../../lib/pdf-crypto';
+import { MonthPicker } from '../../components/MonthPicker';
 import { Cell, Pie, PieChart, Tooltip } from 'recharts';
 
 const API = process.env.NEXT_PUBLIC_API_URL;
@@ -316,12 +317,10 @@ export default function Dashboard() {
           </div>
         ) : (
           <div className="flex items-center gap-3 flex-wrap">
-            <input
-              type="month"
+            <MonthPicker
               value={billingMonth}
-              onChange={(e) => setBillingMonth(e.target.value)}
+              onChange={setBillingMonth}
               disabled={uploading}
-              className="border rounded-lg px-3 py-2 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-400"
             />
             <label className="flex items-center gap-3 cursor-pointer w-fit">
               <span className="px-4 py-2 rounded-lg bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700 transition">

--- a/apps/web/app/mvp/dashboard.tsx
+++ b/apps/web/app/mvp/dashboard.tsx
@@ -447,22 +447,20 @@ export default function Dashboard() {
                         {new Date(t.date).toLocaleDateString('pt-BR')}
                       </td>
                       <td className="py-2 pr-4">
-                        <span className="flex items-center gap-1">
-                          {t.alias ?? t.description}
-                          <button
-                            onClick={() => openEdit(t)}
-                            className="opacity-0 group-hover:opacity-100 text-gray-400 hover:text-indigo-600 transition-opacity"
-                            aria-label="Editar transação"
-                          >
-                            <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
-                              <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
-                            </svg>
-                          </button>
-                        </span>
+                        <span>{t.alias ?? t.description}</span>
                         {t.alias && <span className="block text-xs text-gray-400">{t.description}</span>}
                       </td>
                       <td className="py-2 pr-4">
-                        <span className="text-xs bg-indigo-100 text-indigo-700 px-2 py-0.5 rounded-full">{t.category}</span>
+                        <button
+                          onClick={() => openEdit(t)}
+                          aria-label="Editar categoria"
+                          className="group/cat inline-flex items-center gap-1 text-xs bg-indigo-100 text-indigo-700 px-2 py-0.5 rounded-full hover:bg-indigo-200 active:bg-indigo-300 transition"
+                        >
+                          {t.category}
+                          <svg xmlns="http://www.w3.org/2000/svg" className="w-3 h-3 opacity-40 group-hover/cat:opacity-100 transition-opacity flex-shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden>
+                            <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
+                          </svg>
+                        </button>
                         {t.subcategory && (
                           <span className="ml-1 text-xs text-gray-500">{t.subcategory}</span>
                         )}

--- a/apps/web/components/MonthPicker.tsx
+++ b/apps/web/components/MonthPicker.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+const MONTHS = [
+  'Janeiro', 'Fevereiro', 'Março', 'Abril',
+  'Maio', 'Junho', 'Julho', 'Agosto',
+  'Setembro', 'Outubro', 'Novembro', 'Dezembro',
+];
+
+type Props = {
+  value: string; // YYYY-MM
+  onChange: (value: string) => void;
+  disabled?: boolean;
+};
+
+export function MonthPicker({ value, onChange, disabled }: Props) {
+  const [open, setOpen] = useState(false);
+  const [year, setYear] = useState(() => parseInt(value.split('-')[0]));
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const selectedYear = parseInt(value.split('-')[0]);
+  const selectedMonth = parseInt(value.split('-')[1]) - 1;
+
+  useEffect(() => {
+    if (!open) return;
+    function onMouseDown(e: MouseEvent) {
+      if (!containerRef.current?.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener('mousedown', onMouseDown);
+    return () => document.removeEventListener('mousedown', onMouseDown);
+  }, [open]);
+
+  function toggle() {
+    if (disabled) return;
+    setYear(selectedYear);
+    setOpen((o) => !o);
+  }
+
+  function select(monthIndex: number) {
+    const mm = String(monthIndex + 1).padStart(2, '0');
+    onChange(`${year}-${mm}`);
+    setOpen(false);
+  }
+
+  const label = `${MONTHS[selectedMonth]} de ${selectedYear}`;
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={toggle}
+        disabled={disabled}
+        className="flex items-center gap-2 border rounded-lg px-3 py-2 text-sm text-gray-700 bg-white hover:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400 transition disabled:opacity-50 whitespace-nowrap"
+      >
+        <CalendarIcon />
+        {label}
+        <ChevronIcon open={open} />
+      </button>
+
+      {open && (
+        <div className="absolute top-full mt-1 left-0 z-50 bg-white border rounded-xl shadow-lg p-4 w-60">
+          <div className="flex items-center justify-between mb-3">
+            <button
+              type="button"
+              onClick={() => setYear((y) => y - 1)}
+              className="p-1.5 rounded-lg hover:bg-gray-100 text-gray-500 hover:text-gray-900 transition text-base leading-none"
+              aria-label="Ano anterior"
+            >
+              ‹
+            </button>
+            <span className="font-semibold text-sm text-gray-900">{year}</span>
+            <button
+              type="button"
+              onClick={() => setYear((y) => y + 1)}
+              className="p-1.5 rounded-lg hover:bg-gray-100 text-gray-500 hover:text-gray-900 transition text-base leading-none"
+              aria-label="Próximo ano"
+            >
+              ›
+            </button>
+          </div>
+
+          <div className="grid grid-cols-3 gap-1">
+            {MONTHS.map((month, i) => {
+              const isSelected = year === selectedYear && i === selectedMonth;
+              return (
+                <button
+                  key={month}
+                  type="button"
+                  onClick={() => select(i)}
+                  className={`text-sm rounded-lg py-2 transition ${
+                    isSelected
+                      ? 'bg-indigo-600 text-white font-medium'
+                      : 'text-gray-700 hover:bg-indigo-50 hover:text-indigo-700'
+                  }`}
+                >
+                  {month.slice(0, 3)}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CalendarIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden>
+      <rect x="1" y="3" width="14" height="12" rx="2" />
+      <path d="M1 7h14M5 1v4M11 1v4" />
+    </svg>
+  );
+}
+
+function ChevronIcon({ open }: { open: boolean }) {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden
+      className={`transition-transform ${open ? 'rotate-180' : ''}`}
+    >
+      <path d="M2 4l4 4 4-4" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary

- Substitui `<input type="month">` por `MonthPicker` customizado: popover com grid 3×4 de meses em português, navegação de ano com ‹ ›, label "Setembro de 2025", sem dependências externas
- Linha inteira da tabela de transações vira trigger de edição (`onClick` na `<tr>`) — funciona com toque em mobile sem depender de hover
- Remove o lápis oculto por hover da coluna de descrição
- Badge de categoria simplificado (sem ícone redundante)

## Test plan

- [ ] Seletor de mês abre popover com meses em português e navega entre anos
- [ ] Clicar num mês fecha o popover e atualiza o label
- [ ] Em mobile: tocar em qualquer ponto da linha abre o modal de edição
- [ ] Em desktop: clicar na linha abre o modal de edição

🤖 Generated with [Claude Code](https://claude.com/claude-code)