### PR TITLE
fix(#56): mensagem de erro quando fatura falha no processamento

### DIFF
--- a/apps/web/app/mvp/dashboard.tsx
+++ b/apps/web/app/mvp/dashboard.tsx
@@ -114,9 +114,12 @@ export default function Dashboard() {
         clearInterval(pollingRef.current!);
         pollingRef.current = null;
         fetchInvoices();
+        if (data.status === 'FAILED') {
+          setError('Não foi possível processar a fatura. Verifique se o arquivo enviado é uma fatura de cartão de crédito válida.');
+        }
       }
     }, 3000);
-  }, [fetchDetail, fetchInvoices]);
+  }, [fetchDetail, fetchInvoices, setError]);
 
   function openEdit(t: Transaction) {
     setEditForm({ transaction: t, alias: t.alias ?? t.description, category: t.category, subcategory: t.subcategory ?? '' });


### PR DESCRIPTION
## Summary

- Quando o polling detecta `status === 'FAILED'`, exibe mensagem amigável na seção de upload: _"Não foi possível processar a fatura. Verifique se o arquivo enviado é uma fatura de cartão de crédito válida."_
- O polling já parava em `FAILED` — esse comportamento foi mantido
- `setError` adicionado às dependências do `useCallback`

## Test plan

- [ ] Enviar um PDF que não é fatura e aguardar o processamento falhar → mensagem de erro aparece
- [ ] Enviar uma fatura válida → nenhuma mensagem de erro é exibida
- [ ] Invoice com `FAILED` continua visível no seletor com "(falhou)" e pode ser excluído

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)