### PR TITLE
feat(#65): replicar edição de categoria para transações com mesma descrição

### DIFF
--- a/apps/api/src/invoices/dto/invoice-response.dto.spec.ts
+++ b/apps/api/src/invoices/dto/invoice-response.dto.spec.ts
@@ -19,6 +19,8 @@ describe('InvoiceResponseDto.from', () => {
 
   it('excludes createdAt', () => {
     const dto = InvoiceResponseDto.from(base);
-    expect((dto as unknown as Record<string, unknown>).createdAt).toBeUndefined();
+    expect(
+      (dto as unknown as Record<string, unknown>).createdAt,
+    ).toBeUndefined();
   });
 });

--- a/apps/api/src/invoices/invoices.controller.spec.ts
+++ b/apps/api/src/invoices/invoices.controller.spec.ts
@@ -11,7 +11,9 @@ const mockInvoicesService = {
   delete: jest.fn(),
 };
 
-const billingMonthDto: CreateInvoiceDto = { billingMonth: '2025-09-01T00:00:00.000Z' };
+const billingMonthDto: CreateInvoiceDto = {
+  billingMonth: '2025-09-01T00:00:00.000Z',
+};
 
 describe('InvoicesController', () => {
   let controller: InvoicesController;
@@ -38,7 +40,11 @@ describe('InvoicesController', () => {
     it('should return invoiceId for a valid PDF', async () => {
       mockInvoicesService.create.mockResolvedValue({ invoiceId: 'inv-1' });
 
-      const result = await controller.create('user-1', pdfFile, billingMonthDto);
+      const result = await controller.create(
+        'user-1',
+        pdfFile,
+        billingMonthDto,
+      );
 
       expect(result).toEqual({ invoiceId: 'inv-1' });
       expect(mockInvoicesService.create).toHaveBeenCalledWith(

--- a/apps/api/src/invoices/invoices.service.spec.ts
+++ b/apps/api/src/invoices/invoices.service.spec.ts
@@ -190,7 +190,12 @@ describe('InvoicesService', () => {
       );
 
       await expect(
-        service.create('user-1', encryptedFile, new Date('2025-09-01'), 's3cret'),
+        service.create(
+          'user-1',
+          encryptedFile,
+          new Date('2025-09-01'),
+          's3cret',
+        ),
       ).rejects.toThrow(/qpdf/);
       expect(mockStorageService.upload).not.toHaveBeenCalled();
     });

--- a/apps/api/src/merchant-rules/merchant-rules.repository.spec.ts
+++ b/apps/api/src/merchant-rules/merchant-rules.repository.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { MerchantRuleSource } from '@prisma/client';
+import { MerchantRuleSource, Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { MerchantRulesRepository } from './merchant-rules.repository';
 
@@ -80,6 +80,19 @@ describe('MerchantRulesRepository', () => {
           }) as unknown,
         }),
       );
+    });
+
+    it('uses the provided transaction client when given', async () => {
+      const tx = {
+        merchantRule: {
+          upsert: jest.fn().mockResolvedValue(undefined),
+        },
+      } as unknown as Prisma.TransactionClient;
+
+      await repository.upsert(input, tx);
+
+      expect(tx.merchantRule.upsert).toHaveBeenCalled();
+      expect(mockPrisma.merchantRule.upsert).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/merchant-rules/merchant-rules.repository.spec.ts
+++ b/apps/api/src/merchant-rules/merchant-rules.repository.spec.ts
@@ -91,6 +91,7 @@ describe('MerchantRulesRepository', () => {
 
       await repository.upsert(input, tx);
 
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(tx.merchantRule.upsert).toHaveBeenCalled();
       expect(mockPrisma.merchantRule.upsert).not.toHaveBeenCalled();
     });

--- a/apps/api/src/merchant-rules/merchant-rules.repository.ts
+++ b/apps/api/src/merchant-rules/merchant-rules.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { MerchantRuleSource } from '@prisma/client';
+import { MerchantRuleSource, Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 
 export interface MerchantRuleUpsertData {
@@ -15,15 +15,19 @@ export interface MerchantRuleUpsertData {
 export class MerchantRulesRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  async upsert(data: MerchantRuleUpsertData): Promise<void> {
+  async upsert(
+    data: MerchantRuleUpsertData,
+    tx?: Prisma.TransactionClient,
+  ): Promise<void> {
     const fields = {
       category: data.category,
       subcategory: data.subcategory ?? null,
       confidence: data.confidence,
       source: data.source,
     };
+    const client = tx ?? this.prisma;
 
-    await this.prisma.merchantRule.upsert({
+    await client.merchantRule.upsert({
       where: { userId_pattern: { userId: data.userId, pattern: data.pattern } },
       create: { userId: data.userId, pattern: data.pattern, ...fields },
       update: fields,

--- a/apps/api/src/transactions/dto/bulk-categorize.dto.ts
+++ b/apps/api/src/transactions/dto/bulk-categorize.dto.ts
@@ -1,0 +1,15 @@
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class BulkCategorizeDto {
+  @IsNotEmpty()
+  @IsString()
+  description: string;
+
+  @IsNotEmpty()
+  @IsString()
+  category: string;
+
+  @IsOptional()
+  @IsString()
+  subcategory?: string | null;
+}

--- a/apps/api/src/transactions/transactions.controller.spec.ts
+++ b/apps/api/src/transactions/transactions.controller.spec.ts
@@ -5,6 +5,8 @@ import { TransactionsService } from './transactions.service';
 
 const mockTransactionsService = {
   update: jest.fn(),
+  countByDescription: jest.fn(),
+  bulkCategorize: jest.fn(),
 };
 
 describe('TransactionsController', () => {
@@ -55,6 +57,61 @@ describe('TransactionsController', () => {
       await expect(
         controller.update(transactionId, userId, dto),
       ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('GET /transactions/count', () => {
+    const userId = 'user-1';
+
+    it('delegates to service.countByDescription with userId and description', async () => {
+      mockTransactionsService.countByDescription.mockResolvedValue(15);
+
+      await controller.count(userId, 'UBER');
+
+      expect(mockTransactionsService.countByDescription).toHaveBeenCalledWith(
+        userId,
+        'UBER',
+      );
+    });
+
+    it('returns { count } with the value from the service', async () => {
+      mockTransactionsService.countByDescription.mockResolvedValue(15);
+
+      const result = await controller.count(userId, 'UBER');
+
+      expect(result).toEqual({ count: 15 });
+    });
+  });
+
+  describe('POST /transactions/bulk-categorize', () => {
+    const userId = 'user-1';
+    const dto = {
+      description: 'UBER',
+      category: 'Transporte',
+      subcategory: 'Uber / 99 / Taxi',
+    };
+
+    it('delegates to service.bulkCategorize with userId and dto', async () => {
+      mockTransactionsService.bulkCategorize.mockResolvedValue({
+        updatedCount: 15,
+      });
+
+      await controller.bulkCategorize(userId, dto);
+
+      expect(mockTransactionsService.bulkCategorize).toHaveBeenCalledWith(
+        userId,
+        dto,
+      );
+    });
+
+    it('returns { updatedCount } from the service', async () => {
+      mockTransactionsService.bulkCategorize.mockResolvedValue({
+        updatedCount: 15,
+      });
+
+      const result = await controller.bulkCategorize(userId, dto);
+
+      expect(result).toEqual({ updatedCount: 15 });
     });
   });
 });

--- a/apps/api/src/transactions/transactions.controller.ts
+++ b/apps/api/src/transactions/transactions.controller.ts
@@ -1,12 +1,33 @@
-import { Body, Controller, Param, Put } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Put, Query } from '@nestjs/common';
 import { Transaction } from '@prisma/client';
 import { CurrentUser } from '../auth/current-user.decorator';
+import { BulkCategorizeDto } from './dto/bulk-categorize.dto';
 import { UpdateTransactionDto } from './dto/update-transaction.dto';
 import { TransactionsService } from './transactions.service';
 
 @Controller('transactions')
 export class TransactionsController {
   constructor(private readonly transactionsService: TransactionsService) {}
+
+  @Get('count')
+  async count(
+    @CurrentUser() userId: string,
+    @Query('description') description: string,
+  ): Promise<{ count: number }> {
+    const count = await this.transactionsService.countByDescription(
+      userId,
+      description,
+    );
+    return { count };
+  }
+
+  @Post('bulk-categorize')
+  async bulkCategorize(
+    @CurrentUser() userId: string,
+    @Body() dto: BulkCategorizeDto,
+  ): Promise<{ updatedCount: number }> {
+    return this.transactionsService.bulkCategorize(userId, dto);
+  }
 
   @Put(':id')
   async update(

--- a/apps/api/src/transactions/transactions.repository.spec.ts
+++ b/apps/api/src/transactions/transactions.repository.spec.ts
@@ -133,11 +133,11 @@ describe('TransactionsRepository', () => {
 
       await repository.countByUserAndDescription('user-1', 'UBER');
 
-      const call = mockPrisma.transaction.count.mock.calls[0][0] as {
-        where: { description: unknown };
-      };
-      expect(call.where.description).toBe('UBER');
-      expect(typeof call.where.description).toBe('string');
+      expect(mockPrisma.transaction.count).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ description: 'UBER' }) as unknown,
+        }),
+      );
     });
   });
 
@@ -180,10 +180,13 @@ describe('TransactionsRepository', () => {
         subcategory: null,
       });
 
-      const call = mockPrisma.transaction.updateMany.mock.calls[0][0] as {
-        where: { invoice: { userId: string } };
-      };
-      expect(call.where.invoice).toEqual({ userId: 'user-1' });
+      expect(mockPrisma.transaction.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            invoice: { userId: 'user-1' },
+          }) as unknown,
+        }),
+      );
     });
 
     it('should use the provided transaction client when given', async () => {
@@ -200,6 +203,7 @@ describe('TransactionsRepository', () => {
         tx,
       );
 
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(tx.transaction.updateMany).toHaveBeenCalled();
       expect(mockPrisma.transaction.updateMany).not.toHaveBeenCalled();
       expect(result).toBe(3);
@@ -213,10 +217,11 @@ describe('TransactionsRepository', () => {
         subcategory: null,
       });
 
-      const call = mockPrisma.transaction.updateMany.mock.calls[0][0] as {
-        data: { needsReview: boolean };
-      };
-      expect(call.data.needsReview).toBe(false);
+      expect(mockPrisma.transaction.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ needsReview: false }) as unknown,
+        }),
+      );
     });
   });
 });

--- a/apps/api/src/transactions/transactions.repository.spec.ts
+++ b/apps/api/src/transactions/transactions.repository.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { Prisma } from '@prisma/client';
 import {
   TransactionsRepository,
   TransactionCreateData,
@@ -9,6 +10,8 @@ const mockPrisma = {
   transaction: {
     createMany: jest.fn(),
     findMany: jest.fn(),
+    count: jest.fn(),
+    updateMany: jest.fn(),
   },
 };
 
@@ -89,6 +92,131 @@ describe('TransactionsRepository', () => {
         where: { invoiceId: 'inv-1' },
       });
       expect(result).toBe(rows);
+    });
+  });
+
+  describe('countByUserAndDescription', () => {
+    it('should return 0 when user has no transactions with that description', async () => {
+      mockPrisma.transaction.count.mockResolvedValue(0);
+
+      const result = await repository.countByUserAndDescription(
+        'user-1',
+        'UBER',
+      );
+
+      expect(result).toBe(0);
+    });
+
+    it('should return the count of user transactions matching the description', async () => {
+      mockPrisma.transaction.count.mockResolvedValue(15);
+
+      const result = await repository.countByUserAndDescription(
+        'user-1',
+        'UBER',
+      );
+
+      expect(result).toBe(15);
+    });
+
+    it('should filter by userId via invoice relation (multi-tenancy)', async () => {
+      mockPrisma.transaction.count.mockResolvedValue(0);
+
+      await repository.countByUserAndDescription('user-1', 'UBER');
+
+      expect(mockPrisma.transaction.count).toHaveBeenCalledWith({
+        where: { description: 'UBER', invoice: { userId: 'user-1' } },
+      });
+    });
+
+    it('should use exact description match (not partial)', async () => {
+      mockPrisma.transaction.count.mockResolvedValue(0);
+
+      await repository.countByUserAndDescription('user-1', 'UBER');
+
+      const call = mockPrisma.transaction.count.mock.calls[0][0] as {
+        where: { description: unknown };
+      };
+      expect(call.where.description).toBe('UBER');
+      expect(typeof call.where.description).toBe('string');
+    });
+  });
+
+  describe('updateManyByUserAndDescription', () => {
+    it('should update category and subcategory of all matching transactions', async () => {
+      mockPrisma.transaction.updateMany.mockResolvedValue({ count: 15 });
+
+      await repository.updateManyByUserAndDescription('user-1', 'UBER', {
+        category: 'Transporte',
+        subcategory: 'Uber / 99 / Taxi',
+      });
+
+      expect(mockPrisma.transaction.updateMany).toHaveBeenCalledWith({
+        where: { description: 'UBER', invoice: { userId: 'user-1' } },
+        data: {
+          category: 'Transporte',
+          subcategory: 'Uber / 99 / Taxi',
+          needsReview: false,
+        },
+      });
+    });
+
+    it('should return the number of transactions updated', async () => {
+      mockPrisma.transaction.updateMany.mockResolvedValue({ count: 15 });
+
+      const result = await repository.updateManyByUserAndDescription(
+        'user-1',
+        'UBER',
+        { category: 'Transporte', subcategory: 'Uber / 99 / Taxi' },
+      );
+
+      expect(result).toBe(15);
+    });
+
+    it('should filter by userId via invoice relation (multi-tenancy)', async () => {
+      mockPrisma.transaction.updateMany.mockResolvedValue({ count: 0 });
+
+      await repository.updateManyByUserAndDescription('user-1', 'UBER', {
+        category: 'Transporte',
+        subcategory: null,
+      });
+
+      const call = mockPrisma.transaction.updateMany.mock.calls[0][0] as {
+        where: { invoice: { userId: string } };
+      };
+      expect(call.where.invoice).toEqual({ userId: 'user-1' });
+    });
+
+    it('should use the provided transaction client when given', async () => {
+      const tx = {
+        transaction: {
+          updateMany: jest.fn().mockResolvedValue({ count: 3 }),
+        },
+      } as unknown as Prisma.TransactionClient;
+
+      const result = await repository.updateManyByUserAndDescription(
+        'user-1',
+        'UBER',
+        { category: 'Transporte', subcategory: null },
+        tx,
+      );
+
+      expect(tx.transaction.updateMany).toHaveBeenCalled();
+      expect(mockPrisma.transaction.updateMany).not.toHaveBeenCalled();
+      expect(result).toBe(3);
+    });
+
+    it('should set needsReview to false on updated transactions', async () => {
+      mockPrisma.transaction.updateMany.mockResolvedValue({ count: 0 });
+
+      await repository.updateManyByUserAndDescription('user-1', 'UBER', {
+        category: 'Transporte',
+        subcategory: null,
+      });
+
+      const call = mockPrisma.transaction.updateMany.mock.calls[0][0] as {
+        data: { needsReview: boolean };
+      };
+      expect(call.data.needsReview).toBe(false);
     });
   });
 });

--- a/apps/api/src/transactions/transactions.repository.ts
+++ b/apps/api/src/transactions/transactions.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Transaction, TransactionType } from '@prisma/client';
+import { Prisma, Transaction, TransactionType } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 
 export interface TransactionCreateData {
@@ -61,5 +61,32 @@ export class TransactionsRepository {
     },
   ): Promise<Transaction> {
     return this.prisma.transaction.update({ where: { id }, data });
+  }
+
+  async countByUserAndDescription(
+    userId: string,
+    description: string,
+  ): Promise<number> {
+    return this.prisma.transaction.count({
+      where: { description, invoice: { userId } },
+    });
+  }
+
+  async updateManyByUserAndDescription(
+    userId: string,
+    description: string,
+    data: { category: string; subcategory: string | null },
+    tx?: Prisma.TransactionClient,
+  ): Promise<number> {
+    const client = tx ?? this.prisma;
+    const result = await client.transaction.updateMany({
+      where: { description, invoice: { userId } },
+      data: {
+        category: data.category,
+        subcategory: data.subcategory,
+        needsReview: false,
+      },
+    });
+    return result.count;
   }
 }

--- a/apps/api/src/transactions/transactions.service.spec.ts
+++ b/apps/api/src/transactions/transactions.service.spec.ts
@@ -233,9 +233,7 @@ describe('TransactionsService', () => {
     it('propagates errors when the merchant rule upsert fails', async () => {
       mockMerchantRulesRepository.upsert.mockRejectedValue(new Error('boom'));
 
-      await expect(service.bulkCategorize(userId, dto)).rejects.toThrow(
-        'boom',
-      );
+      await expect(service.bulkCategorize(userId, dto)).rejects.toThrow('boom');
     });
 
     it('treats missing subcategory as null', async () => {

--- a/apps/api/src/transactions/transactions.service.spec.ts
+++ b/apps/api/src/transactions/transactions.service.spec.ts
@@ -1,7 +1,8 @@
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { MerchantRuleSource } from '@prisma/client';
+import { MerchantRuleSource, Prisma } from '@prisma/client';
 import { MerchantRulesRepository } from '../merchant-rules/merchant-rules.repository';
+import { PrismaService } from '../prisma/prisma.service';
 import { UpdateTransactionDto } from './dto/update-transaction.dto';
 import { TransactionsRepository } from './transactions.repository';
 import { TransactionsService } from './transactions.service';
@@ -9,10 +10,20 @@ import { TransactionsService } from './transactions.service';
 const mockTransactionsRepository = {
   findByIdAndUserId: jest.fn(),
   update: jest.fn(),
+  countByUserAndDescription: jest.fn(),
+  updateManyByUserAndDescription: jest.fn(),
 };
 
 const mockMerchantRulesRepository = {
   upsert: jest.fn(),
+};
+
+const mockTx = { __mock: 'tx' } as unknown as Prisma.TransactionClient;
+const mockPrisma = {
+  $transaction: jest.fn(
+    async <T>(callback: (tx: Prisma.TransactionClient) => Promise<T>) =>
+      callback(mockTx),
+  ),
 };
 
 describe('TransactionsService', () => {
@@ -30,11 +41,19 @@ describe('TransactionsService', () => {
           provide: MerchantRulesRepository,
           useValue: mockMerchantRulesRepository,
         },
+        {
+          provide: PrismaService,
+          useValue: mockPrisma,
+        },
       ],
     }).compile();
 
     service = module.get(TransactionsService);
     jest.clearAllMocks();
+    mockPrisma.$transaction.mockImplementation(
+      async <T>(callback: (tx: Prisma.TransactionClient) => Promise<T>) =>
+        callback(mockTx),
+    );
   });
 
   describe('update', () => {
@@ -128,6 +147,114 @@ describe('TransactionsService', () => {
           category: 'Transporte',
           subcategory: null,
         }),
+      );
+    });
+  });
+
+  describe('countByDescription', () => {
+    it('delegates to repository and returns the count', async () => {
+      mockTransactionsRepository.countByUserAndDescription.mockResolvedValue(
+        15,
+      );
+
+      const result = await service.countByDescription('user-1', 'UBER');
+
+      expect(
+        mockTransactionsRepository.countByUserAndDescription,
+      ).toHaveBeenCalledWith('user-1', 'UBER');
+      expect(result).toBe(15);
+    });
+  });
+
+  describe('bulkCategorize', () => {
+    const userId = 'user-1';
+    const dto = {
+      description: 'UBER',
+      category: 'Transporte',
+      subcategory: 'Uber / 99 / Taxi',
+    };
+
+    beforeEach(() => {
+      mockTransactionsRepository.updateManyByUserAndDescription.mockResolvedValue(
+        15,
+      );
+      mockMerchantRulesRepository.upsert.mockResolvedValue(undefined);
+    });
+
+    it('calls updateManyByUserAndDescription with description, category and tx client', async () => {
+      await service.bulkCategorize(userId, dto);
+
+      expect(
+        mockTransactionsRepository.updateManyByUserAndDescription,
+      ).toHaveBeenCalledWith(
+        userId,
+        dto.description,
+        { category: dto.category, subcategory: dto.subcategory },
+        mockTx,
+      );
+    });
+
+    it('upserts a MerchantRule with USER_CORRECTION source and confidence 1.0', async () => {
+      await service.bulkCategorize(userId, dto);
+
+      expect(mockMerchantRulesRepository.upsert).toHaveBeenCalledWith(
+        {
+          userId,
+          pattern: dto.description,
+          category: dto.category,
+          subcategory: dto.subcategory,
+          confidence: 1.0,
+          source: MerchantRuleSource.USER_CORRECTION,
+        },
+        mockTx,
+      );
+    });
+
+    it('runs updateMany and upsert atomically inside prisma.$transaction', async () => {
+      await service.bulkCategorize(userId, dto);
+
+      expect(mockPrisma.$transaction).toHaveBeenCalledTimes(1);
+      expect(
+        mockTransactionsRepository.updateManyByUserAndDescription,
+      ).toHaveBeenCalled();
+      expect(mockMerchantRulesRepository.upsert).toHaveBeenCalled();
+    });
+
+    it('returns updatedCount with the number of affected transactions', async () => {
+      mockTransactionsRepository.updateManyByUserAndDescription.mockResolvedValue(
+        15,
+      );
+
+      const result = await service.bulkCategorize(userId, dto);
+
+      expect(result).toEqual({ updatedCount: 15 });
+    });
+
+    it('propagates errors when the merchant rule upsert fails', async () => {
+      mockMerchantRulesRepository.upsert.mockRejectedValue(new Error('boom'));
+
+      await expect(service.bulkCategorize(userId, dto)).rejects.toThrow(
+        'boom',
+      );
+    });
+
+    it('treats missing subcategory as null', async () => {
+      await service.bulkCategorize(userId, {
+        description: 'UBER',
+        category: 'Transporte',
+      });
+
+      expect(
+        mockTransactionsRepository.updateManyByUserAndDescription,
+      ).toHaveBeenCalledWith(
+        userId,
+        'UBER',
+        { category: 'Transporte', subcategory: null },
+        expect.anything(),
+      );
+      expect(mockMerchantRulesRepository.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ subcategory: null }),
+        expect.anything(),
       );
     });
   });

--- a/apps/api/src/transactions/transactions.service.ts
+++ b/apps/api/src/transactions/transactions.service.ts
@@ -1,6 +1,8 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { MerchantRuleSource, Transaction } from '@prisma/client';
 import { MerchantRulesRepository } from '../merchant-rules/merchant-rules.repository';
+import { PrismaService } from '../prisma/prisma.service';
+import { BulkCategorizeDto } from './dto/bulk-categorize.dto';
 import { UpdateTransactionDto } from './dto/update-transaction.dto';
 import { TransactionsRepository } from './transactions.repository';
 
@@ -9,6 +11,7 @@ export class TransactionsService {
   constructor(
     private readonly transactionsRepository: TransactionsRepository,
     private readonly merchantRulesRepository: MerchantRulesRepository,
+    private readonly prisma: PrismaService,
   ) {}
 
   async update(
@@ -41,5 +44,43 @@ export class TransactionsService {
     ]);
 
     return updated;
+  }
+
+  async countByDescription(
+    userId: string,
+    description: string,
+  ): Promise<number> {
+    return this.transactionsRepository.countByUserAndDescription(
+      userId,
+      description,
+    );
+  }
+
+  async bulkCategorize(
+    userId: string,
+    dto: BulkCategorizeDto,
+  ): Promise<{ updatedCount: number }> {
+    const subcategory = dto.subcategory ?? null;
+    return this.prisma.$transaction(async (tx) => {
+      const updatedCount =
+        await this.transactionsRepository.updateManyByUserAndDescription(
+          userId,
+          dto.description,
+          { category: dto.category, subcategory },
+          tx,
+        );
+      await this.merchantRulesRepository.upsert(
+        {
+          userId,
+          pattern: dto.description,
+          category: dto.category,
+          subcategory,
+          confidence: 1.0,
+          source: MerchantRuleSource.USER_CORRECTION,
+        },
+        tx,
+      );
+      return { updatedCount };
+    });
   }
 }

--- a/apps/web/app/mvp/dashboard.tsx
+++ b/apps/web/app/mvp/dashboard.tsx
@@ -64,6 +64,9 @@ export default function Dashboard() {
   const [selectedSubcategories, setSelectedSubcategories] = useState<string[]>([]);
   const [filterType, setFilterType] = useState<'ALL' | 'DEBIT' | 'CREDIT'>('ALL');
   const [editForm, setEditForm] = useState<{ transaction: Transaction; alias: string; category: string; subcategory: string } | null>(null);
+  const [matchCount, setMatchCount] = useState<number | null>(null);
+  const [applyToAll, setApplyToAll] = useState(false);
+  const [bulkConfirmOpen, setBulkConfirmOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const [pendingFile, setPendingFile] = useState<{ name: string; bytes: Uint8Array } | null>(null);
   const [pdfPassword, setPdfPassword] = useState('');
@@ -73,6 +76,7 @@ export default function Dashboard() {
     return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
   });
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const matchCountAbortRef = useRef<AbortController | null>(null);
 
   const headers = useCallback(async () => {
     const token = await getToken();
@@ -121,12 +125,43 @@ export default function Dashboard() {
     }, 3000);
   }, [fetchDetail, fetchInvoices, setError]);
 
-  function openEdit(t: Transaction) {
+  async function openEdit(t: Transaction) {
     setEditForm({ transaction: t, alias: t.alias ?? t.description, category: t.category, subcategory: t.subcategory ?? '' });
+    setApplyToAll(false);
+    setMatchCount(null);
+
+    matchCountAbortRef.current?.abort();
+    const controller = new AbortController();
+    matchCountAbortRef.current = controller;
+
+    try {
+      const h = await headers();
+      const res = await fetch(
+        `${API}/transactions/count?description=${encodeURIComponent(t.description)}`,
+        { headers: h, signal: controller.signal },
+      );
+      if (res.ok) {
+        const { count } = (await res.json()) as { count: number };
+        setMatchCount(count);
+      }
+    } catch (err) {
+      if ((err as Error).name !== 'AbortError') setMatchCount(null);
+    }
+  }
+
+  function closeEdit() {
+    setEditForm(null);
+    setApplyToAll(false);
+    setMatchCount(null);
+    setBulkConfirmOpen(false);
   }
 
   async function handleSaveEdit() {
     if (!editForm) return;
+    if (applyToAll) {
+      setBulkConfirmOpen(true);
+      return;
+    }
     setSaving(true);
     try {
       const h = await headers();
@@ -146,7 +181,29 @@ export default function Dashboard() {
           ? { ...prev, transactions: prev.transactions.map((t) => (t.id === updated.id ? updated : t)) }
           : prev,
       );
-      setEditForm(null);
+      closeEdit();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleConfirmBulk() {
+    if (!editForm) return;
+    setSaving(true);
+    try {
+      const h = await headers();
+      const res = await fetch(`${API}/transactions/bulk-categorize`, {
+        method: 'POST',
+        headers: { ...h, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          description: editForm.transaction.description,
+          category: editForm.category,
+          subcategory: editForm.subcategory || null,
+        }),
+      });
+      if (!res.ok) throw new Error('Erro ao atualizar em massa');
+      if (selectedId) await fetchDetail(selectedId);
+      closeEdit();
     } finally {
       setSaving(false);
     }
@@ -592,8 +649,12 @@ export default function Dashboard() {
                   type="text"
                   value={editForm.alias}
                   onChange={(e) => setEditForm((f) => f && { ...f, alias: e.target.value })}
-                  className="w-full text-sm border border-gray-300 rounded-lg px-3 py-2 text-gray-700"
+                  disabled={applyToAll}
+                  className="w-full text-sm border border-gray-300 rounded-lg px-3 py-2 text-gray-700 disabled:bg-gray-100 disabled:text-gray-400"
                 />
+                {applyToAll && (
+                  <p className="text-xs text-gray-400 mt-1">Nome exibido não se aplica a edição em massa</p>
+                )}
               </div>
               <div>
                 <label className="block text-xs text-gray-500 mb-1">Categoria</label>
@@ -618,10 +679,24 @@ export default function Dashboard() {
                   </select>
                 </div>
               )}
+              {matchCount !== null && matchCount > 1 && (
+                <label className="flex items-start gap-2 cursor-pointer pt-1">
+                  <input
+                    type="checkbox"
+                    checked={applyToAll}
+                    onChange={(e) => setApplyToAll(e.target.checked)}
+                    className="mt-0.5"
+                  />
+                  <span className="text-sm text-gray-700">
+                    Aplicar a todas as {matchCount} transações com{' '}
+                    <span className="font-medium">&quot;{editForm.transaction.description}&quot;</span>
+                  </span>
+                </label>
+              )}
             </div>
             <div className="flex justify-end gap-3 mt-6">
               <button
-                onClick={() => setEditForm(null)}
+                onClick={closeEdit}
                 disabled={saving}
                 className="px-4 py-2 text-sm rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50 transition disabled:opacity-50"
               >
@@ -632,7 +707,42 @@ export default function Dashboard() {
                 disabled={saving}
                 className="px-4 py-2 text-sm rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 transition disabled:opacity-50"
               >
-                {saving ? 'Salvando…' : 'Salvar'}
+                {saving
+                  ? 'Salvando…'
+                  : applyToAll && matchCount
+                    ? `Aplicar a ${matchCount} transações`
+                    : 'Salvar'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {bulkConfirmOpen && editForm && matchCount !== null && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+          <div className="bg-white rounded-xl border p-6 max-w-sm w-full mx-4 shadow-lg">
+            <h3 className="font-semibold text-gray-900 mb-2">Atualizar {matchCount} transações?</h3>
+            <p className="text-sm text-gray-600 mb-4">
+              Todas as transações com a descrição{' '}
+              <span className="font-medium">&quot;{editForm.transaction.description}&quot;</span> serão categorizadas
+              como <span className="font-medium">{editForm.category}</span>
+              {editForm.subcategory && <> / <span className="font-medium">{editForm.subcategory}</span></>}.
+              Esta ação não pode ser desfeita.
+            </p>
+            <div className="flex justify-end gap-3">
+              <button
+                onClick={() => setBulkConfirmOpen(false)}
+                disabled={saving}
+                className="px-4 py-2 text-sm rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50 transition disabled:opacity-50"
+              >
+                Cancelar
+              </button>
+              <button
+                onClick={handleConfirmBulk}
+                disabled={saving}
+                className="px-4 py-2 text-sm rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 transition disabled:opacity-50"
+              >
+                {saving ? 'Aplicando…' : 'Confirmar'}
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Resumo

Quando o usuário corrige a categoria de uma transação, pode optar por replicar a correção para **todas as transações** com a mesma descrição — em todas as faturas do usuário.

**Backend**
- `GET /transactions/count?description=` — retorna o total de transações com aquela descrição exata
- `POST /transactions/bulk-categorize` — atualiza todas as transações e cria/atualiza uma `MerchantRule` em operação atômica via `prisma.$transaction`

**Frontend**
- Checkbox no modal de edição (aparece apenas se houver mais de 1 transação com a mesma descrição)
- Modal de confirmação separado exibe o total de transações que serão afetadas

**Qualidade**
- Multi-tenancy preservado: todas as queries filtradas por `userId` via relação `invoice`
- 14 novos testes unitários (repository, service, controller)

Fecha #65.

---

## Como testar no Postman

> Pré-requisito: obter um JWT válido do Clerk e configurar como variável `{{token}}` no Postman. Adicionar o header `Authorization: Bearer {{token}}` em todas as requests (ou configurar no nível da Collection).

### 1. Contar transações por descrição

| Campo | Valor |
|---|---|
| Método | `GET` |
| URL | `http://localhost:3333/transactions/count` |
| Query param | `description` = `UBER *TRIP` |

**Resposta esperada (200)**
```json
{ "count": 15 }
```

Comportamentos a verificar:
- Descrição inexistente → `{ "count": 0 }`
- Match é **exato** (não parcial)
- Conta transações em todas as faturas do usuário

---

### 2. Categorizar todas as transações da descrição

| Campo | Valor |
|---|---|
| Método | `POST` |
| URL | `http://localhost:3333/transactions/bulk-categorize` |
| Content-Type | `application/json` |

**Body**
```json
{
  "description": "UBER *TRIP",
  "category": "Transporte",
  "subcategory": "Uber / 99 / Taxi"
}
```

**Resposta esperada (200)**
```json
{ "updatedCount": 15 }
```

Comportamentos a verificar:
- `subcategory` é opcional — pode ser omitido ou enviado como `null`
- `description` e `category` ausentes → 400 Bad Request
- Operação atômica: se o upsert da `MerchantRule` falhar, o `updateMany` é revertido
- Define `needsReview: false` em todas as transações atualizadas

---

### 3. Verificar isolamento entre usuários

Subir faturas com duas contas diferentes, ambas contendo `UBER *TRIP`:

- `GET /transactions/count` de cada conta deve retornar apenas suas próprias transações
- `POST /transactions/bulk-categorize` de uma conta não deve alterar as transações da outra
- A `MerchantRule` criada é isolada por `(userId, pattern)`

---

### 4. Verificar criação da MerchantRule

Após o `POST bulk-categorize`, confirmar no Prisma Studio ou via SQL:

```sql
SELECT * FROM "MerchantRule"
WHERE "userId" = '<seu-user-id>'
  AND pattern = 'UBER *TRIP';
-- source = USER_CORRECTION, confidence = 1.0
```

Chamar o endpoint duas vezes com a mesma descrição → deve fazer **upsert** (sem duplicar a regra).

---

## Test plan

- [ ] `GET /transactions/count` retorna o número correto para a descrição
- [ ] `GET /transactions/count` com descrição inexistente retorna `{ "count": 0 }`
- [ ] `POST /transactions/bulk-categorize` atualiza todas as transações e retorna `updatedCount`
- [ ] `POST /transactions/bulk-categorize` cria `MerchantRule` com `source: USER_CORRECTION`
- [ ] Chamado duas vezes com a mesma descrição → upsert (sem duplicar `MerchantRule`)
- [ ] Endpoints não vazam transações entre usuários (testar com duas contas)
- [ ] `POST` sem `category` retorna 400
- [ ] Frontend: checkbox aparece apenas se `count > 1`
- [ ] Frontend: modal de confirmação exibe a contagem correta antes de confirmar
- [ ] Frontend: após confirmar, a fatura reflete as categorias atualizadas

🤖 Generated with [Claude Code](https://claude.com/claude-code)