### PR TITLE
feat(#70): ambiente local Docker + STORAGE_PREFIX no StorageService

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,26 +130,31 @@ These skills must be invoked using the Skill tool — not just referenced mental
 ## Useful commands
 
 ```bash
-# From root (via Turborepo)
-pnpm build            # build all apps
-pnpm test             # run all tests
+# Docker stack (postgres + api)
+make dev                         # sobe stack, segue logs da api
+make dev-stop                    # para containers
+make dev-reset                   # limpa volumes (banco zerado)
+make migrate                     # aplica migrations pendentes (prisma migrate deploy)
+make migrate-create NAME=foo     # cria nova migration a partir do schema.prisma
+make migrate-reset               # reset completo (apaga e re-aplica tudo)
+make studio                      # Prisma Studio
 
-# Makefile shortcuts (from root)
-make dev-api          # API dev server (port 3333)
-make dev-web          # Web dev server (port 3000)
-make test             # run all tests
-make health           # check API health
+# Execução no host (sem Docker)
+make dev-web                     # Next.js (porta 3000)
+make dev-api                     # NestJS direto (porta 3333)
+
+# Comuns
+make build                       # build all apps
+make test                        # all tests
+make health                      # API health check
 
 # API (apps/api)
-pnpm test             # unit tests
-pnpm test:watch       # watch mode
-pnpm test:e2e         # e2e tests
-pnpm start:dev        # dev server with hot reload
-
-# Web (apps/web)
-pnpm dev              # dev server
-pnpm build            # production build
+pnpm test                        # unit tests
+pnpm test:watch                  # watch mode
+pnpm test:e2e                    # e2e tests
 ```
+
+> Setup completo do ambiente local em `CONTRIBUTING.md`.
 
 ## End of day
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,107 @@
+# Contribuindo com o Luppa
+
+Guia rápido para subir o ambiente de desenvolvimento.
+
+## Pré-requisitos
+
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) (com Docker Compose v2)
+- [Node.js 22+](https://nodejs.org/) (para rodar a web no host)
+- [pnpm 10+](https://pnpm.io/installation): `npm install -g pnpm`
+
+## Setup em 3 passos
+
+### 1. Configurar variáveis de ambiente
+
+```bash
+cp apps/api/.env.example apps/api/.env
+cp apps/web/.env.example apps/web/.env
+```
+
+Preencha as chaves nos dois `.env`:
+
+- **Clerk** (instância dev): `dashboard.clerk.com` → API keys
+- **Supabase**: `app.supabase.com` → Project Settings → API
+- **Anthropic**: `console.anthropic.com` → API keys
+
+> O `DATABASE_URL` no `apps/api/.env` é ignorado quando rodando via `make dev` — o docker-compose injeta o URL do postgres local.
+
+### 2. Subir api + postgres
+
+```bash
+make dev
+```
+
+Sobe postgres + api em containers. Segue os logs da api no terminal (Ctrl+C interrompe o tail; os containers continuam rodando — `make dev-stop` para tudo).
+
+### 3. Aplicar migrations e subir a web
+
+```bash
+make migrate         # roda prisma migrate dev no postgres local
+pnpm --filter web dev   # web no host (mais rápido que dentro do container)
+```
+
+A API fica em `http://localhost:3333/health` e a web em `http://localhost:3000`.
+
+## Comandos úteis
+
+| Comando | O que faz |
+|---------|-----------|
+| `make dev` | Sobe postgres + api e segue logs da api |
+| `make dev-logs` | Logs combinados dos dois containers |
+| `make dev-stop` | Para os containers (preserva dados) |
+| `make dev-reset` | Para containers **e remove volumes** (limpa o banco local) |
+| `make migrate` | Aplica migrations pendentes (`prisma migrate deploy`) |
+| `make migrate-create NAME=foo` | Cria nova migration a partir do `schema.prisma` |
+| `make migrate-reset` | Apaga o banco local e re-aplica tudo do zero |
+| `make studio` | Abre Prisma Studio |
+| `make test` | Suite de testes (jest) |
+
+### Criando uma nova migration
+
+1. Edite `apps/api/prisma/schema.prisma` com a mudança desejada.
+2. Rode `make migrate-create NAME=descricao_curta` (ex: `add_invoice_currency`).
+3. O Prisma gera o SQL em `apps/api/prisma/migrations/<timestamp>_<nome>/migration.sql` e aplica no banco local.
+4. Commit do diretório gerado + do `schema.prisma`.
+5. Em produção (Railway), o `prisma migrate deploy` no startup do container aplica a migration automaticamente.
+
+> **Importante**: nunca edite migrations já aplicadas em produção. O `prisma migrate deploy` ignora drift de checksum, mas times que rodem `migrate dev` localmente vão precisar de reset (`make migrate-reset`) para limpar.
+
+## Estrutura de ambientes
+
+| | Postgres | Storage | Clerk |
+|---|---|---|---|
+| **Local** | container do compose (`luppa_local`) | Supabase com `STORAGE_PREFIX=local/` | instância dev |
+| **Produção** (Railway) | Supabase | Supabase com `STORAGE_PREFIX=prod/` | instância prod |
+
+Storage é compartilhado entre ambientes; isolamento via prefixo no path. Banco é totalmente separado.
+
+## Troubleshooting
+
+### Porta 5432 ocupada
+
+Você tem um postgres rodando no host. Pare ele (`brew services stop postgresql`) ou mude a porta exposta no `docker-compose.yml` (linha `5432:5432` → `5433:5432`) e ajuste o `DATABASE_URL` injetado para `localhost:5433` apenas quando acessar do host (Prisma Studio). De dentro do container, a porta continua 5432.
+
+### Schema mudou e o Prisma Client tá desatualizado
+
+O `start:dev` não regenera o client. Quando alterar `schema.prisma`:
+
+```bash
+make migrate     # cria/aplica a migration
+docker compose restart api  # restart pega o novo client
+```
+
+### `make dev` falha no boot da api com erro de native binding
+
+Volume mounts misturados podem corromper o `node_modules` do container. Resolva limpando os volumes nomeados:
+
+```bash
+make dev-reset && make dev
+```
+
+### Web não acha a API
+
+A web roda no host (porta 3000) e bate na api em `http://localhost:3333`. Se preferir rodar a web em container futuramente, use `host.docker.internal` ou adicione um service no compose.
+
+## Dúvidas
+
+Abra uma issue ou pergunte no grupo do projeto.

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,45 @@
-.PHONY: dev-api dev-web build test health migrate migrate-dev studio
+.PHONY: dev dev-logs dev-stop dev-reset dev-api dev-web build test health migrate migrate-create migrate-reset migrate-deploy studio
+
+# --- Ambiente local via Docker (postgres + api) ---
+
+dev:
+	docker compose up -d
+	docker compose logs -f api
+
+dev-logs:
+	docker compose logs -f
+
+dev-stop:
+	docker compose stop
+
+dev-reset:
+	docker compose down -v
+
+migrate:
+	docker compose exec -T api pnpm exec prisma migrate deploy
+
+# Cria uma nova migration a partir do schema.prisma.
+# Uso: make migrate-create NAME=add_some_field
+migrate-create:
+	@test -n "$(NAME)" || (echo "Uso: make migrate-create NAME=descricao_da_migration"; exit 1)
+	docker compose exec api pnpm exec prisma migrate dev --name $(NAME)
+
+# Apaga o banco local e re-aplica todas as migrations do zero.
+migrate-reset:
+	docker compose exec -T api pnpm exec prisma migrate reset --force --skip-seed
+
+studio:
+	docker compose exec -T api pnpm exec prisma studio
+
+# --- Execução direta no host (sem Docker) ---
 
 dev-api:
 	cd apps/api && pnpm start:dev
 
 dev-web:
 	cd apps/web && pnpm dev
+
+# --- Comuns ---
 
 build:
 	pnpm build
@@ -17,9 +52,3 @@ health:
 
 migrate-deploy:
 	cd apps/api && npx prisma migrate deploy
-
-migrate-dev:
-	cd apps/api && npx prisma migrate dev
-
-studio:
-	cd apps/api && npx prisma studio

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ SaaS de controle financeiro pessoal. Usuários fazem upload de PDFs de fatura de
 
 ## Pré-requisitos
 
-- Node.js 22+
+- Docker Desktop (com Docker Compose v2)
+- Node.js 22+ (para rodar a web no host)
 - pnpm 10+
 - Acesso aos serviços externos (ver seção de acessos abaixo)
 
@@ -50,25 +51,14 @@ pnpm install
 cp apps/api/.env.example apps/api/.env
 ```
 
-Edite `apps/api/.env` com os valores reais:
+Preencha `apps/api/.env` com os valores reais. As chaves obrigatórias estão comentadas no `.env.example`:
 
-```env
-NODE_ENV=development
-PORT=3333
+- `CLERK_SECRET_KEY` / `CLERK_AUTHORIZED_PARTIES` — dashboard.clerk.com → API Keys (instância dev)
+- `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` — Supabase → Settings → API
+- `ANTHROPIC_API_KEY` — console.anthropic.com → API Keys
+- `STORAGE_PREFIX=local/` — isola seus uploads dos arquivos de prod no mesmo bucket
 
-# Clerk — dashboard.clerk.com → API Keys
-CLERK_SECRET_KEY=sk_test_...
-CLERK_AUTHORIZED_PARTIES=http://localhost:3000
-
-# Supabase — Settings → API
-DATABASE_URL=postgresql://postgres.[ref]:[password]@aws-0-[region].pooler.supabase.com:6543/postgres?pgbouncer=true
-DIRECT_URL=postgresql://postgres.[ref]:[password]@aws-0-[region].pooler.supabase.com:5432/postgres
-SUPABASE_URL=https://[ref].supabase.co
-SUPABASE_SERVICE_ROLE_KEY=eyJ...
-
-# Anthropic — console.anthropic.com → API Keys
-ANTHROPIC_API_KEY=sk-ant-...
-```
+> `DATABASE_URL` e `DIRECT_URL` são sobrescritos pelo `docker-compose.yml` apontando para o postgres local. Você só precisa de valores válidos aqui se for rodar a API fora do Docker (`make dev-api`).
 
 ### Variáveis de ambiente — Web
 
@@ -89,22 +79,20 @@ NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
 NEXT_PUBLIC_MAINTENANCE_MODE=false
 ```
 
-### Banco de dados
-
-```bash
-# Aplica as migrations no banco
-make migrate-deploy
-```
-
 ---
 
 ## Rodando localmente
 
-```bash
-# Terminal 1 — API (http://localhost:3333)
-make dev-api
+API + postgres sobem em Docker; web roda no host (Next.js fica mais rápido fora do container).
 
-# Terminal 2 — Web (http://localhost:3000)
+```bash
+# Terminal 1 — sobe postgres + api e segue logs (http://localhost:3333)
+make dev
+
+# Primeira vez, ou sempre que o schema mudar
+make migrate
+
+# Terminal 2 — web (http://localhost:3000)
 make dev-web
 ```
 
@@ -115,19 +103,30 @@ make health
 # { "status": "OK" }
 ```
 
+Guia detalhado em [`CONTRIBUTING.md`](CONTRIBUTING.md) (troubleshooting, criar nova migration, etc).
+
 ---
 
 ## Comandos úteis
 
 ```bash
-make dev-api        # API em modo watch (porta 3333)
-make dev-web        # Web em modo watch (porta 3000)
-make test           # todos os testes (API + web)
-make build          # build de todos os apps
-make health         # health check da API
-make migrate-deploy # aplica migrations (banco já existente)
-make migrate-dev    # cria nova migration (desenvolvimento)
-make studio         # Prisma Studio (GUI do banco)
+# Docker (postgres + api)
+make dev                       # sobe stack e segue logs
+make dev-stop                  # para containers (preserva dados)
+make dev-reset                 # apaga volumes (banco zerado)
+make migrate                   # aplica migrations pendentes
+make migrate-create NAME=foo   # cria nova migration a partir do schema.prisma
+make migrate-reset             # reset completo + re-aplica tudo
+make studio                    # Prisma Studio
+
+# Host
+make dev-web                   # Next.js (3000)
+make dev-api                   # NestJS direto, sem Docker (3333)
+
+# Comuns
+make test                      # suite de testes
+make build                     # build de todos os apps
+make health                    # health check da API
 ```
 
 ---
@@ -160,6 +159,14 @@ docs/
 O bucket `invoices` precisa existir no Supabase Storage com visibilidade **private**.
 
 Para criar: Supabase Dashboard → Storage → New bucket → nome: `invoices` → Private.
+
+Arquivos são isolados por ambiente via `STORAGE_PREFIX`:
+
+```
+invoices/
+├── prod/{userId}/...   ← produção (STORAGE_PREFIX=prod/ no Railway)
+└── local/{userId}/...  ← seu desenvolvimento (STORAGE_PREFIX=local/)
+```
 
 ---
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,25 +1,31 @@
-# Application
-# Determines storage path prefix: 'dev/' for non-production, 'prod/' for production
+# Servidor
 NODE_ENV=development
 PORT=3333
 
 # CORS — origens permitidas separadas por vírgula
 # Local: http://localhost:3000 | Produção: https://luppin.app
-# Se não definido em produção, todas as origens são bloqueadas
 CORS_ORIGIN=http://localhost:3000
 
-# Auth (Clerk)
+# Auth (Clerk — usar instância dev em https://dashboard.clerk.com)
 CLERK_SECRET_KEY=sk_test_...
-# Comma-separated list of allowed frontend origins
 CLERK_AUTHORIZED_PARTIES=http://localhost:3000
+CLERK_WEBHOOK_SECRET=whsec_...
 
 # Claude API (Anthropic)
 ANTHROPIC_API_KEY=sk-ant-...
 
-# Database (Supabase PostgreSQL)
-# Transaction pooler — used by the app at runtime (port 6543)
-DATABASE_URL=postgresql://postgres.[project-ref]:[password]@aws-0-[region].pooler.supabase.com:6543/postgres?pgbouncer=true
+# Banco de dados (Supabase em prod / postgres do docker-compose em local)
+# Ao rodar via `make dev`, estas vars são sobrescritas pelo docker-compose
+# apontando para o postgres local. Mantenha valores válidos aqui se for rodar
+# a API fora do compose (`make dev-api`).
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/luppa_local?schema=public
+DIRECT_URL=postgresql://postgres:postgres@localhost:5432/luppa_local?schema=public
 
-# Direct connection — used by Prisma Migrate only (port 5432)
-# Note: special characters in the password must be URL-encoded (e.g. @ → %40)
-DIRECT_URL=postgresql://postgres.[project-ref]:[password]@aws-0-[region].pooler.supabase.com:5432/postgres
+# Supabase Storage (mesmo bucket de prod; isolamento por STORAGE_PREFIX)
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=eyJ...
+
+# Prefixo aplicado a todos os uploads para isolar ambientes no mesmo bucket.
+# local/ em dev local, dev/ em staging futura, prod/ em produção (Railway).
+# Obrigatório: a aplicação não inicia sem esta var.
+STORAGE_PREFIX=local/

--- a/apps/api/Dockerfile.dev
+++ b/apps/api/Dockerfile.dev
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1
+# Dockerfile para desenvolvimento local. NÃO usado em produção.
+# Build context: raiz do monorepo (mesmo padrão do Dockerfile de prod).
+
+FROM node:22-alpine
+WORKDIR /workspace
+
+RUN apk add --no-cache qpdf openssl \
+  && npm install -g pnpm@10.33.0
+
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY apps/api/package.json ./apps/api/
+COPY packages/types/package.json ./packages/types/
+
+RUN pnpm install --frozen-lockfile
+
+WORKDIR /workspace/apps/api
+EXPOSE 3333
+
+CMD ["sh", "-c", "pnpm exec prisma generate && pnpm start:dev"]

--- a/apps/api/prisma/migrations/20260519000000_enable_rls_public_tables/migration.sql
+++ b/apps/api/prisma/migrations/20260519000000_enable_rls_public_tables/migration.sql
@@ -1,8 +1,10 @@
 -- Enable RLS on all public tables to block direct PostgREST access.
 -- Prisma connects via DATABASE_URL with a role that has BYPASSRLS,
 -- so application behavior is unchanged.
+-- Note: _prisma_migrations (internal Prisma table) is intentionally excluded
+-- because altering it inside a migration breaks shadow DB validation in
+-- `prisma migrate dev`. RLS there must be enabled out-of-band if needed.
 ALTER TABLE "User" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "Invoice" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "Transaction" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "MerchantRule" ENABLE ROW LEVEL SECURITY;
-ALTER TABLE "_prisma_migrations" ENABLE ROW LEVEL SECURITY;

--- a/apps/api/src/invoices/invoices.service.spec.ts
+++ b/apps/api/src/invoices/invoices.service.spec.ts
@@ -5,7 +5,6 @@ import {
   NotFoundException,
   UnprocessableEntityException,
 } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InvoicesService } from './invoices.service';
 import { InvoicesRepository } from './invoices.repository';
@@ -33,7 +32,7 @@ const file = {
   mimetype: 'application/pdf',
 } as Express.Multer.File;
 
-async function createService(nodeEnv: string): Promise<InvoicesService> {
+async function createService(): Promise<InvoicesService> {
   const module: TestingModule = await Test.createTestingModule({
     providers: [
       InvoicesService,
@@ -41,10 +40,6 @@ async function createService(nodeEnv: string): Promise<InvoicesService> {
       { provide: InvoicesRepository, useValue: mockInvoicesRepository },
       { provide: EventEmitter2, useValue: mockEventEmitter },
       { provide: PdfDecryptionService, useValue: mockPdfDecryptionService },
-      {
-        provide: ConfigService,
-        useValue: { get: jest.fn().mockReturnValue(nodeEnv) },
-      },
     ],
   }).compile();
   return module.get<InvoicesService>(InvoicesService);
@@ -53,19 +48,19 @@ async function createService(nodeEnv: string): Promise<InvoicesService> {
 describe('InvoicesService', () => {
   beforeEach(() => jest.resetAllMocks());
 
-  describe('create (development)', () => {
+  describe('create', () => {
     let service: InvoicesService;
 
     beforeEach(async () => {
-      service = await createService('development');
+      service = await createService();
     });
 
-    it('should upload under dev/ prefix, create invoice, emit event and return invoiceId', async () => {
-      mockStorageService.upload.mockResolvedValue('dev/user-1/fatura.pdf');
+    it('should upload with user-scoped path, create invoice, emit event and return invoiceId', async () => {
+      mockStorageService.upload.mockResolvedValue('local/user-1/fatura.pdf');
       mockInvoicesRepository.create.mockResolvedValue({
         id: 'inv-1',
         userId: 'user-1',
-        storagePath: 'dev/user-1/fatura.pdf',
+        storagePath: 'local/user-1/fatura.pdf',
       });
       const billingMonth = new Date('2025-09-01');
 
@@ -73,14 +68,14 @@ describe('InvoicesService', () => {
 
       expect(mockStorageService.upload).toHaveBeenCalledWith(
         'invoices',
-        expect.stringMatching(/^dev\/user-1\//),
+        expect.stringMatching(/^user-1\/\d+-fatura\.pdf$/),
         file.buffer,
         'application/pdf',
       );
       expect(mockInvoicesRepository.create).toHaveBeenCalledWith({
         userId: 'user-1',
         filename: 'fatura.pdf',
-        storagePath: 'dev/user-1/fatura.pdf',
+        storagePath: 'local/user-1/fatura.pdf',
         billingMonth,
       });
       expect(mockEventEmitter.emit).toHaveBeenCalledWith(
@@ -103,7 +98,7 @@ describe('InvoicesService', () => {
     });
 
     it('should not emit event if repository create fails', async () => {
-      mockStorageService.upload.mockResolvedValue('dev/user-1/fatura.pdf');
+      mockStorageService.upload.mockResolvedValue('local/user-1/fatura.pdf');
       mockInvoicesRepository.create.mockRejectedValue(new Error('db error'));
 
       await expect(
@@ -124,7 +119,7 @@ describe('InvoicesService', () => {
     } as Express.Multer.File;
 
     beforeEach(async () => {
-      service = await createService('development');
+      service = await createService();
     });
 
     it('should throw UnprocessableEntityException when no password is provided', async () => {
@@ -138,11 +133,11 @@ describe('InvoicesService', () => {
     it('should decrypt and upload the decrypted buffer when password is correct', async () => {
       const decrypted = Buffer.from('decrypted-pdf');
       mockPdfDecryptionService.decrypt.mockResolvedValue(decrypted);
-      mockStorageService.upload.mockResolvedValue('dev/user-1/fatura.pdf');
+      mockStorageService.upload.mockResolvedValue('local/user-1/fatura.pdf');
       mockInvoicesRepository.create.mockResolvedValue({
         id: 'inv-1',
         userId: 'user-1',
-        storagePath: 'dev/user-1/fatura.pdf',
+        storagePath: 'local/user-1/fatura.pdf',
       });
 
       const result = await service.create(
@@ -158,7 +153,7 @@ describe('InvoicesService', () => {
       );
       expect(mockStorageService.upload).toHaveBeenCalledWith(
         'invoices',
-        expect.stringMatching(/^dev\/user-1\//),
+        expect.stringMatching(/^user-1\/\d+-fatura\.pdf$/),
         decrypted,
         'application/pdf',
       );
@@ -201,37 +196,11 @@ describe('InvoicesService', () => {
     });
   });
 
-  describe('create (production)', () => {
-    let service: InvoicesService;
-
-    beforeEach(async () => {
-      service = await createService('production');
-    });
-
-    it('should upload under prod/ prefix', async () => {
-      mockStorageService.upload.mockResolvedValue('prod/user-1/fatura.pdf');
-      mockInvoicesRepository.create.mockResolvedValue({
-        id: 'inv-1',
-        userId: 'user-1',
-        storagePath: 'prod/user-1/fatura.pdf',
-      });
-
-      await service.create('user-1', file, new Date('2025-09-01'));
-
-      expect(mockStorageService.upload).toHaveBeenCalledWith(
-        'invoices',
-        expect.stringMatching(/^prod\/user-1\//),
-        file.buffer,
-        'application/pdf',
-      );
-    });
-  });
-
   describe('findAll', () => {
     let service: InvoicesService;
 
     beforeEach(async () => {
-      service = await createService('development');
+      service = await createService();
     });
 
     it('should return invoices for the given userId', async () => {
@@ -251,7 +220,7 @@ describe('InvoicesService', () => {
     let service: InvoicesService;
 
     beforeEach(async () => {
-      service = await createService('development');
+      service = await createService();
     });
 
     it('should return the invoice with transactions when found', async () => {
@@ -281,7 +250,7 @@ describe('InvoicesService', () => {
     let service: InvoicesService;
 
     beforeEach(async () => {
-      service = await createService('development');
+      service = await createService();
     });
 
     it('should throw NotFoundException when invoice is not found', async () => {
@@ -295,7 +264,7 @@ describe('InvoicesService', () => {
     it('should call deleteById and storageService.delete on success', async () => {
       mockInvoicesRepository.findById.mockResolvedValue({
         id: 'inv-1',
-        storagePath: 'dev/user-1/fatura.pdf',
+        storagePath: 'local/user-1/fatura.pdf',
       });
       mockInvoicesRepository.deleteById.mockResolvedValue(undefined);
       mockStorageService.delete.mockResolvedValue(undefined);
@@ -308,14 +277,14 @@ describe('InvoicesService', () => {
       );
       expect(mockStorageService.delete).toHaveBeenCalledWith(
         'invoices',
-        'dev/user-1/fatura.pdf',
+        'local/user-1/fatura.pdf',
       );
     });
 
     it('should not throw when storageService.delete fails', async () => {
       mockInvoicesRepository.findById.mockResolvedValue({
         id: 'inv-1',
-        storagePath: 'dev/user-1/fatura.pdf',
+        storagePath: 'local/user-1/fatura.pdf',
       });
       mockInvoicesRepository.deleteById.mockResolvedValue(undefined);
       mockStorageService.delete.mockRejectedValue(new Error('storage error'));
@@ -326,7 +295,7 @@ describe('InvoicesService', () => {
     it('should log error when storageService.delete fails', async () => {
       mockInvoicesRepository.findById.mockResolvedValue({
         id: 'inv-1',
-        storagePath: 'dev/user-1/fatura.pdf',
+        storagePath: 'local/user-1/fatura.pdf',
       });
       mockInvoicesRepository.deleteById.mockResolvedValue(undefined);
       mockStorageService.delete.mockRejectedValue(new Error('storage error'));

--- a/apps/api/src/invoices/invoices.service.ts
+++ b/apps/api/src/invoices/invoices.service.ts
@@ -4,7 +4,6 @@ import {
   NotFoundException,
   UnprocessableEntityException,
 } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Invoice } from '@prisma/client';
 import { StorageService } from '../storage/storage.service';
@@ -22,18 +21,13 @@ import {
 @Injectable()
 export class InvoicesService {
   private readonly logger = new Logger(InvoicesService.name);
-  private readonly envPrefix: string;
 
   constructor(
     private readonly storageService: StorageService,
     private readonly invoicesRepository: InvoicesRepository,
     private readonly eventEmitter: EventEmitter2,
     private readonly pdfDecryptionService: PdfDecryptionService,
-    config: ConfigService,
-  ) {
-    this.envPrefix =
-      config.get<string>('NODE_ENV') === 'production' ? 'prod' : 'dev';
-  }
+  ) {}
 
   private isEncryptedPdf(buffer: Buffer): boolean {
     return buffer.toString('latin1').includes('/Encrypt');
@@ -68,7 +62,7 @@ export class InvoicesService {
 
     const storagePath = await this.storageService.upload(
       INVOICES_BUCKET,
-      `${this.envPrefix}/${userId}/${Date.now()}-${file.originalname}`,
+      `${userId}/${Date.now()}-${file.originalname}`,
       buffer,
       file.mimetype,
     );

--- a/apps/api/src/storage/storage.service.spec.ts
+++ b/apps/api/src/storage/storage.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { InternalServerErrorException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { StorageService } from './storage.service';
 import { SUPABASE_CLIENT } from './storage.constants';
 
@@ -9,20 +10,28 @@ const mockSupabaseClient = {
   },
 };
 
+const mockConfigService = {
+  getOrThrow: jest.fn(),
+};
+
+async function createService(prefix: string): Promise<StorageService> {
+  mockConfigService.getOrThrow.mockReturnValue(prefix);
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      StorageService,
+      { provide: SUPABASE_CLIENT, useValue: mockSupabaseClient },
+      { provide: ConfigService, useValue: mockConfigService },
+    ],
+  }).compile();
+  return module.get<StorageService>(StorageService);
+}
+
 describe('StorageService', () => {
   let service: StorageService;
 
   beforeEach(async () => {
     jest.resetAllMocks();
-
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        StorageService,
-        { provide: SUPABASE_CLIENT, useValue: mockSupabaseClient },
-      ],
-    }).compile();
-
-    service = module.get<StorageService>(StorageService);
+    service = await createService('');
   });
 
   describe('upload', () => {
@@ -60,6 +69,75 @@ describe('StorageService', () => {
           'application/pdf',
         ),
       ).rejects.toThrow(InternalServerErrorException);
+    });
+
+    it('should prepend STORAGE_PREFIX=local/ to the path before calling Supabase', async () => {
+      service = await createService('local/');
+      const uploadMock = jest.fn().mockResolvedValue({
+        data: { path: 'local/user-1/file.pdf' },
+        error: null,
+      });
+      mockSupabaseClient.storage.from.mockReturnValue({ upload: uploadMock });
+
+      const result = await service.upload(
+        'invoices',
+        'user-1/file.pdf',
+        Buffer.from('pdf'),
+        'application/pdf',
+      );
+
+      expect(mockSupabaseClient.storage.from).toHaveBeenCalledWith('invoices');
+      expect(uploadMock).toHaveBeenCalledWith(
+        'local/user-1/file.pdf',
+        Buffer.from('pdf'),
+        expect.objectContaining({ contentType: 'application/pdf' }),
+      );
+      expect(result).toBe('local/user-1/file.pdf');
+    });
+
+    it('should prepend STORAGE_PREFIX=prod/ to the path before calling Supabase', async () => {
+      service = await createService('prod/');
+      const uploadMock = jest.fn().mockResolvedValue({
+        data: { path: 'prod/user-1/file.pdf' },
+        error: null,
+      });
+      mockSupabaseClient.storage.from.mockReturnValue({ upload: uploadMock });
+
+      const result = await service.upload(
+        'invoices',
+        'user-1/file.pdf',
+        Buffer.from('pdf'),
+        'application/pdf',
+      );
+
+      expect(uploadMock).toHaveBeenCalledWith(
+        'prod/user-1/file.pdf',
+        Buffer.from('pdf'),
+        expect.objectContaining({ contentType: 'application/pdf' }),
+      );
+      expect(result).toBe('prod/user-1/file.pdf');
+    });
+
+    it('should pass the path unchanged when STORAGE_PREFIX is empty', async () => {
+      service = await createService('');
+      const uploadMock = jest.fn().mockResolvedValue({
+        data: { path: 'user-1/file.pdf' },
+        error: null,
+      });
+      mockSupabaseClient.storage.from.mockReturnValue({ upload: uploadMock });
+
+      await service.upload(
+        'invoices',
+        'user-1/file.pdf',
+        Buffer.from('pdf'),
+        'application/pdf',
+      );
+
+      expect(uploadMock).toHaveBeenCalledWith(
+        'user-1/file.pdf',
+        Buffer.from('pdf'),
+        expect.objectContaining({ contentType: 'application/pdf' }),
+      );
     });
   });
 
@@ -113,6 +191,26 @@ describe('StorageService', () => {
       await expect(
         service.delete('invoices', 'user-1/file.pdf'),
       ).rejects.toThrow(InternalServerErrorException);
+    });
+  });
+
+  describe('configuration', () => {
+    it('should fail to instantiate when STORAGE_PREFIX is not defined', async () => {
+      const failingConfig = {
+        getOrThrow: jest.fn().mockImplementation(() => {
+          throw new Error('STORAGE_PREFIX is not defined');
+        }),
+      };
+
+      await expect(
+        Test.createTestingModule({
+          providers: [
+            StorageService,
+            { provide: SUPABASE_CLIENT, useValue: mockSupabaseClient },
+            { provide: ConfigService, useValue: failingConfig },
+          ],
+        }).compile(),
+      ).rejects.toThrow(/STORAGE_PREFIX/);
     });
   });
 });

--- a/apps/api/src/storage/storage.service.ts
+++ b/apps/api/src/storage/storage.service.ts
@@ -3,14 +3,20 @@ import {
   Injectable,
   InternalServerErrorException,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { SUPABASE_CLIENT } from './storage.constants';
 
 @Injectable()
 export class StorageService {
+  private readonly prefix: string;
+
   constructor(
     @Inject(SUPABASE_CLIENT) private readonly supabase: SupabaseClient,
-  ) {}
+    config: ConfigService,
+  ) {
+    this.prefix = config.getOrThrow<string>('STORAGE_PREFIX');
+  }
 
   async upload(
     bucket: string,
@@ -20,7 +26,7 @@ export class StorageService {
   ): Promise<string> {
     const { data, error } = await this.supabase.storage
       .from(bucket)
-      .upload(path, file, {
+      .upload(`${this.prefix}${path}`, file, {
         contentType: mimeType,
         upsert: false,
       });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,50 @@
 services:
-  api:
-    build:
-      context: ./apps/api
+  postgres:
+    image: postgres:16-alpine
+    container_name: luppa-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
     ports:
-      - "${PORT:-3333}:${PORT:-3333}"
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./docker/postgres/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  api:
+    container_name: luppa-api
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile.dev
+    restart: unless-stopped
+    ports:
+      - "3333:3333"
     env_file:
       - ./apps/api/.env
     environment:
-      - NODE_ENV=development
-    develop:
-      watch:
-        - action: sync+restart
-          path: ./apps/api/src
-          target: /app/src
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/luppa_local?schema=public
+      DIRECT_URL: postgresql://postgres:postgres@postgres:5432/luppa_local?schema=public
+      STORAGE_PREFIX: local/
+      NODE_ENV: development
+      PORT: 3333
+      CHOKIDAR_USEPOLLING: "true"
+    volumes:
+      - ./apps/api:/workspace/apps/api
+      - ./packages/types:/workspace/packages/types
+      - api_node_modules:/workspace/apps/api/node_modules
+      - root_node_modules:/workspace/node_modules
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+volumes:
+  postgres_data:
+  api_node_modules:
+  root_node_modules:

--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -1,0 +1,5 @@
+-- Inicialização do postgres local.
+-- O banco "postgres" default é criado pelo entrypoint; aqui criamos os do projeto.
+
+CREATE DATABASE luppa_local;
+CREATE DATABASE luppa_test;


### PR DESCRIPTION
Closes #70

## Summary

- Sobe stack local (postgres + api) via docker-compose com hot reload e isolamento total de dados de produção
- Centraliza o prefix de storage no `StorageService` via `STORAGE_PREFIX` (era construído no `InvoicesService` baseado em `NODE_ENV`)
- Adiciona targets Makefile pro fluxo Docker + `CONTRIBUTING.md` com guia de setup

## O que muda

### Backend
- `StorageService` injeta `ConfigService` e prepend `STORAGE_PREFIX` apenas em `upload()`. `download`/`delete` recebem o path completo do DB → zero migração de dados
- `InvoicesService` perde a lógica `envPrefix` (`NODE_ENV === 'production' ? 'prod' : 'dev'`) — passa só `${userId}/${timestamp}-${filename}`
- Fail-fast: `getOrThrow('STORAGE_PREFIX')` força a env var a estar setada em todos os ambientes

### Infra local
- `docker-compose.yml`: postgres 16-alpine (com `luppa_local` + `luppa_test`) + api com `Dockerfile.dev`
- Context da imagem na raiz do monorepo (alinhado com Dockerfile de prod)
- Named volume para `node_modules` (evita conflito de arquitetura host vs container)
- DATABASE_URL injetada via `environment:` (sobrescreve env_file que aponta pro Supabase)
- `prisma migrate deploy` **não** roda no startup do container local (só em prod)

### Migration histórica
- Removida linha `ALTER TABLE "_prisma_migrations" ENABLE ROW LEVEL SECURITY` da migration `enable_rls_public_tables` — causava `P3006` no shadow DB do `prisma migrate dev`. Sem efeito em prod (migration já aplicada lá, e RLS em tabela interna do Prisma não tem propósito real de segurança)

### Documentação
- `CONTRIBUTING.md` novo: setup em 3 passos + troubleshooting + criar nova migration
- `README.md` atualizado: Docker como pré-requisito, novos comandos, isolamento por STORAGE_PREFIX
- `CLAUDE.md` atualizado: seção "Useful commands" com targets Docker

## Ação manual antes do merge

Adicionar `STORAGE_PREFIX=prod/` no painel Railway (env vars da API). Sem essa var a API não inicia (fail-fast).

## Test plan

- [x] 127/127 testes unitários da API passando
- [x] `make dev` sobe postgres + api em máquina zerada
- [x] `make migrate` aplica todas as 8 migrations em DB fresh
- [x] `make migrate` em DB sincronizado → "No pending migrations"
- [x] `make migrate-reset` ciclo completo (apaga + re-aplica)
- [x] `curl /health` retorna `{"status":"OK"}`
- [x] `STORAGE_PREFIX` ausente → API falha no boot com erro claro
- [x] `apps/api/Dockerfile` (produção) e `railway.json` intocados

🤖 Generated with [Claude Code](https://claude.com/claude-code)