### PR TITLE
feat(extraction): 3 buckets, self-check e seleção de modelo por banco

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -32,6 +32,7 @@
     "@supabase/supabase-js": "^2.105.4",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
+    "pdf-parse": "^2.4.5",
     "prisma": "^6.19.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",

--- a/apps/api/src/extraction/bank-detector.service.spec.ts
+++ b/apps/api/src/extraction/bank-detector.service.spec.ts
@@ -1,0 +1,88 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BankDetectorService } from './bank-detector.service';
+
+const getText = jest.fn();
+const destroy = jest.fn();
+
+jest.mock('pdf-parse', () => ({
+  PDFParse: jest.fn().mockImplementation(() => ({
+    getText: (...args: unknown[]) => getText(...args) as unknown,
+    destroy: (): unknown => destroy() as unknown,
+  })),
+}));
+
+const pdf = Buffer.from('fake-pdf');
+
+async function createService(): Promise<BankDetectorService> {
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [BankDetectorService],
+  }).compile();
+  return module.get<BankDetectorService>(BankDetectorService);
+}
+
+describe('BankDetectorService', () => {
+  let service: BankDetectorService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    destroy.mockResolvedValue(undefined);
+    service = await createService();
+  });
+
+  it.each([
+    'ITAU UNIBANCO HOLDING S.A.',
+    'Itaú',
+    'Pague sua fatura - itau',
+    'ITAÚ',
+  ])('detects itau from text containing %p', async (text) => {
+    getText.mockResolvedValue({ text });
+
+    expect(await service.detect(pdf)).toBe('itau');
+  });
+
+  it.each(['Aplicativo Bradesco', 'BRADESCO S.A.', 'bradesco'])(
+    'detects bradesco from text containing %p',
+    async (text) => {
+      getText.mockResolvedValue({ text });
+
+      expect(await service.detect(pdf)).toBe('bradesco');
+    },
+  );
+
+  it.each(['Nubank', 'Nu Pagamentos S.A.', 'NUBANK'])(
+    'detects nubank from text containing %p',
+    async (text) => {
+      getText.mockResolvedValue({ text });
+
+      expect(await service.detect(pdf)).toBe('nubank');
+    },
+  );
+
+  it('returns "other" when no bank identifier is found', async () => {
+    getText.mockResolvedValue({ text: 'some unrelated text' });
+
+    expect(await service.detect(pdf)).toBe('other');
+  });
+
+  it('returns "other" when parsing throws', async () => {
+    getText.mockRejectedValue(new Error('corrupt'));
+
+    expect(await service.detect(pdf)).toBe('other');
+  });
+
+  it('reads only the first page (first: 1)', async () => {
+    getText.mockResolvedValue({ text: 'Itaú' });
+
+    await service.detect(pdf);
+
+    expect(getText).toHaveBeenCalledWith({ first: 1 });
+  });
+
+  it('destroys the parser after use', async () => {
+    getText.mockResolvedValue({ text: 'Itaú' });
+
+    await service.detect(pdf);
+
+    expect(destroy).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/extraction/bank-detector.service.ts
+++ b/apps/api/src/extraction/bank-detector.service.ts
@@ -1,0 +1,36 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PDFParse } from 'pdf-parse';
+
+export type DetectedBank = 'itau' | 'bradesco' | 'nubank' | 'other';
+
+const BANK_PATTERNS: Array<{ regex: RegExp; bank: DetectedBank }> = [
+  { regex: /ita[uú]/i, bank: 'itau' },
+  { regex: /bradesco/i, bank: 'bradesco' },
+  { regex: /nubank|nu\s+pagamentos/i, bank: 'nubank' },
+];
+
+@Injectable()
+export class BankDetectorService {
+  private readonly logger = new Logger(BankDetectorService.name);
+
+  async detect(pdf: Buffer): Promise<DetectedBank> {
+    let text: string;
+    const parser = new PDFParse({ data: pdf });
+    try {
+      const result = await parser.getText({ first: 1 });
+      text = result.text;
+    } catch (err) {
+      this.logger.warn(
+        `Failed to parse PDF for bank detection: ${(err as Error).message}`,
+      );
+      return 'other';
+    } finally {
+      await parser.destroy().catch(() => undefined);
+    }
+
+    for (const { regex, bank } of BANK_PATTERNS) {
+      if (regex.test(text)) return bank;
+    }
+    return 'other';
+  }
+}

--- a/apps/api/src/extraction/extraction.constants.ts
+++ b/apps/api/src/extraction/extraction.constants.ts
@@ -1,2 +1,3 @@
 export const ANTHROPIC_CLIENT = Symbol('ANTHROPIC_CLIENT');
-export const EXTRACTION_MODEL = 'claude-haiku-4-5-20251001';
+export const EXTRACTION_MODEL_DEFAULT = 'claude-haiku-4-5-20251001';
+export const EXTRACTION_MODEL_COMPLEX = 'claude-sonnet-4-6';

--- a/apps/api/src/extraction/extraction.module.ts
+++ b/apps/api/src/extraction/extraction.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import Anthropic from '@anthropic-ai/sdk';
 import { ExtractionService } from './extraction.service';
+import { BankDetectorService } from './bank-detector.service';
 import { ANTHROPIC_CLIENT } from './extraction.constants';
 
 @Module({
@@ -14,6 +15,7 @@ import { ANTHROPIC_CLIENT } from './extraction.constants';
           apiKey: config.getOrThrow<string>('ANTHROPIC_API_KEY'),
         }),
     },
+    BankDetectorService,
     ExtractionService,
   ],
   exports: [ExtractionService],

--- a/apps/api/src/extraction/extraction.service.integration.spec.ts
+++ b/apps/api/src/extraction/extraction.service.integration.spec.ts
@@ -1,9 +1,6 @@
 import 'dotenv/config';
-import { spawn } from 'child_process';
-import { randomUUID } from 'crypto';
-import { readFile, unlink, writeFile } from 'fs/promises';
+import { readFile } from 'fs/promises';
 import { join } from 'path';
-import { tmpdir } from 'os';
 import { Test, TestingModule } from '@nestjs/testing';
 import Anthropic from '@anthropic-ai/sdk';
 import { ExtractionService } from './extraction.service';
@@ -15,47 +12,8 @@ const describeIf = RUN ? describe : describe.skip;
 
 const TESTDATA_DIR = join(__dirname, 'testdata');
 
-const PASSWORDS: Record<string, string> = {
-  'itau-peu.pdf': '91570',
-};
-
-async function decryptPdf(buffer: Buffer, password: string): Promise<Buffer> {
-  const id = randomUUID();
-  const inputPath = join(tmpdir(), `qpdf-in-${id}.pdf`);
-  const outputPath = join(tmpdir(), `qpdf-out-${id}.pdf`);
-  await writeFile(inputPath, buffer);
-  try {
-    await new Promise<void>((resolve, reject) => {
-      const proc = spawn('qpdf', [
-        `--password=${password}`,
-        '--decrypt',
-        inputPath,
-        outputPath,
-      ]);
-      const errs: Buffer[] = [];
-      proc.stderr.on('data', (c: Buffer) => errs.push(c));
-      proc.on('error', reject);
-      proc.on('close', (code) => {
-        if (code === 0) resolve();
-        else
-          reject(new Error(`qpdf failed: ${Buffer.concat(errs).toString()}`));
-      });
-    });
-    return await readFile(outputPath);
-  } finally {
-    await Promise.all([
-      unlink(inputPath).catch(() => undefined),
-      unlink(outputPath).catch(() => undefined),
-    ]);
-  }
-}
-
 async function loadPdf(filename: string): Promise<Buffer> {
-  const pdf = await readFile(join(TESTDATA_DIR, filename));
-  if (PASSWORDS[filename]) {
-    return decryptPdf(pdf, PASSWORDS[filename]);
-  }
-  return pdf;
+  return readFile(join(TESTDATA_DIR, filename));
 }
 
 const EXCLUSION_PATTERNS = [
@@ -106,13 +64,6 @@ describeIf('ExtractionService (integration)', () => {
   jest.setTimeout(300_000);
 
   const cases: ExpectedCase[] = [
-    {
-      file: 'itau-peu.pdf',
-      expectedTotal: 3271.51,
-      label: 'Itaú Peu',
-      expectPayments: true,
-      expectFutureInstallments: false,
-    },
     {
       file: 'itau-humberto.pdf',
       expectedTotal: 18918.07,

--- a/apps/api/src/extraction/extraction.service.integration.spec.ts
+++ b/apps/api/src/extraction/extraction.service.integration.spec.ts
@@ -1,0 +1,188 @@
+import 'dotenv/config';
+import { spawn } from 'child_process';
+import { randomUUID } from 'crypto';
+import { readFile, unlink, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { Test, TestingModule } from '@nestjs/testing';
+import Anthropic from '@anthropic-ai/sdk';
+import { ExtractionService } from './extraction.service';
+import { BankDetectorService } from './bank-detector.service';
+import { ANTHROPIC_CLIENT } from './extraction.constants';
+
+const RUN = process.env.RUN_EXTRACTION_INTEGRATION === '1';
+const describeIf = RUN ? describe : describe.skip;
+
+const TESTDATA_DIR = join(__dirname, 'testdata');
+
+const PASSWORDS: Record<string, string> = {
+  'itau-peu.pdf': '91570',
+};
+
+async function decryptPdf(buffer: Buffer, password: string): Promise<Buffer> {
+  const id = randomUUID();
+  const inputPath = join(tmpdir(), `qpdf-in-${id}.pdf`);
+  const outputPath = join(tmpdir(), `qpdf-out-${id}.pdf`);
+  await writeFile(inputPath, buffer);
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const proc = spawn('qpdf', [
+        `--password=${password}`,
+        '--decrypt',
+        inputPath,
+        outputPath,
+      ]);
+      const errs: Buffer[] = [];
+      proc.stderr.on('data', (c: Buffer) => errs.push(c));
+      proc.on('error', reject);
+      proc.on('close', (code) => {
+        if (code === 0) resolve();
+        else
+          reject(new Error(`qpdf failed: ${Buffer.concat(errs).toString()}`));
+      });
+    });
+    return await readFile(outputPath);
+  } finally {
+    await Promise.all([
+      unlink(inputPath).catch(() => undefined),
+      unlink(outputPath).catch(() => undefined),
+    ]);
+  }
+}
+
+async function loadPdf(filename: string): Promise<Buffer> {
+  const pdf = await readFile(join(TESTDATA_DIR, filename));
+  if (PASSWORDS[filename]) {
+    return decryptPdf(pdf, PASSWORDS[filename]);
+  }
+  return pdf;
+}
+
+const EXCLUSION_PATTERNS = [
+  /saldo anterior/i,
+  /fatura anterior/i,
+  /saldo restante da fatura anterior/i,
+  /pagamento (recebido|em \d)/i,
+  /pagto\.?\s*por\s*deb/i,
+  /pagamento\s+deb\s+automatic/i,
+  /próximas?\s+faturas?/i,
+];
+
+interface ExpectedCase {
+  file: string;
+  expectedTotal: number;
+  label: string;
+  expectPayments: boolean;
+  expectFutureInstallments: boolean;
+}
+
+function sumNet(
+  transactions: Array<{ amount: number; type: 'debit' | 'credit' }>,
+) {
+  return transactions.reduce(
+    (acc, t) => acc + (t.type === 'credit' ? -t.amount : t.amount),
+    0,
+  );
+}
+
+describeIf('ExtractionService (integration)', () => {
+  let service: ExtractionService;
+
+  beforeAll(async () => {
+    if (!process.env.ANTHROPIC_API_KEY) {
+      throw new Error('ANTHROPIC_API_KEY required for integration tests');
+    }
+    const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ExtractionService,
+        BankDetectorService,
+        { provide: ANTHROPIC_CLIENT, useValue: client },
+      ],
+    }).compile();
+    service = module.get<ExtractionService>(ExtractionService);
+  });
+
+  jest.setTimeout(300_000);
+
+  const cases: ExpectedCase[] = [
+    {
+      file: 'itau-peu.pdf',
+      expectedTotal: 3271.51,
+      label: 'Itaú Peu',
+      expectPayments: true,
+      expectFutureInstallments: false,
+    },
+    {
+      file: 'itau-humberto.pdf',
+      expectedTotal: 18918.07,
+      label: 'Itaú Humberto',
+      expectPayments: true,
+      expectFutureInstallments: true,
+    },
+    {
+      file: 'Nubank_2026-05-18.pdf',
+      expectedTotal: 1138.35,
+      label: 'Nubank',
+      expectPayments: true,
+      expectFutureInstallments: false,
+    },
+    {
+      file: 'Bradesco_ExtratoFaturaAberta-23-05-2026-compactado.pdf',
+      expectedTotal: 3992.33,
+      label: 'Bradesco',
+      expectPayments: true,
+      expectFutureInstallments: false,
+    },
+  ];
+
+  for (const c of cases) {
+    describe(c.label, () => {
+      let result: Awaited<ReturnType<ExtractionService['extract']>>;
+
+      beforeAll(async () => {
+        const pdf = await loadPdf(c.file);
+        result = await service.extract(pdf);
+      });
+
+      it('invoiceTotal and sum match (±R$ 0,01)', () => {
+        expect(result.invoiceTotal).toBeCloseTo(c.expectedTotal, 2);
+        expect(sumNet(result.transactions)).toBeCloseTo(c.expectedTotal, 2);
+      });
+
+      it('no excluded patterns in descriptions', () => {
+        for (const t of result.transactions) {
+          for (const pattern of EXCLUSION_PATTERNS) {
+            expect(t.description).not.toMatch(pattern);
+          }
+        }
+      });
+
+      it('every amount is positive', () => {
+        for (const t of result.transactions) {
+          expect(t.amount).toBeGreaterThan(0);
+          expect(['debit', 'credit']).toContain(t.type);
+        }
+      });
+
+      if (c.expectPayments) {
+        it('payments array is populated with valid entries', () => {
+          expect(result.payments.length).toBeGreaterThan(0);
+          for (const p of result.payments) {
+            expect(p.amount).toBeGreaterThan(0);
+            expect(['invoice_payment', 'previous_balance']).toContain(p.kind);
+          }
+        });
+      }
+
+      if (c.expectFutureInstallments) {
+        it('futureInstallments array is populated with valid entries', () => {
+          expect(result.futureInstallments.length).toBeGreaterThan(0);
+          for (const f of result.futureInstallments) {
+            expect(f.amount).toBeGreaterThan(0);
+          }
+        });
+      }
+    });
+  }
+});

--- a/apps/api/src/extraction/extraction.service.spec.ts
+++ b/apps/api/src/extraction/extraction.service.spec.ts
@@ -1,17 +1,29 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ExtractionService } from './extraction.service';
+import { BankDetectorService } from './bank-detector.service';
 import { ANTHROPIC_CLIENT } from './extraction.constants';
 
 const mockAnthropicClient = { messages: { create: jest.fn() } };
+const mockBankDetector = { detect: jest.fn() };
 
 const pdf = Buffer.from('fake-pdf');
 
-function makeToolUseResponse(invoiceTotal: number, transactions: object[]) {
+function makeToolUseResponse(
+  invoiceTotal: number,
+  transactions: object[],
+  payments: object[] = [],
+  futureInstallments: object[] = [],
+) {
   return {
     content: [
       {
         type: 'tool_use',
-        input: { invoiceTotal, transactions },
+        input: {
+          invoiceTotal,
+          transactions,
+          payments,
+          futureInstallments,
+        },
       },
     ],
   };
@@ -22,6 +34,7 @@ async function createService(): Promise<ExtractionService> {
     providers: [
       ExtractionService,
       { provide: ANTHROPIC_CLIENT, useValue: mockAnthropicClient },
+      { provide: BankDetectorService, useValue: mockBankDetector },
     ],
   }).compile();
   return module.get<ExtractionService>(ExtractionService);
@@ -32,10 +45,11 @@ describe('ExtractionService', () => {
 
   beforeEach(async () => {
     jest.resetAllMocks();
+    mockBankDetector.detect.mockResolvedValue('other');
     service = await createService();
   });
 
-  it('should return extracted transactions on success', async () => {
+  it('should return invoiceTotal alongside transactions', async () => {
     mockAnthropicClient.messages.create.mockResolvedValue(
       makeToolUseResponse(100.0, [
         {
@@ -61,8 +75,9 @@ describe('ExtractionService', () => {
 
     const result = await service.extract(pdf);
 
-    expect(result).toHaveLength(2);
-    expect(result[0]).toEqual({
+    expect(result.invoiceTotal).toBe(100.0);
+    expect(result.transactions).toHaveLength(2);
+    expect(result.transactions[0]).toEqual({
       date: '2025-04-10',
       description: 'UBER *TRIP',
       amount: 60.0,
@@ -71,7 +86,48 @@ describe('ExtractionService', () => {
       subcategory: 'Uber / 99 / Taxi',
       confidence: 0.95,
     });
-    expect(result[1].category).toBe('Assinaturas');
+    expect(result.transactions[1].category).toBe('Assinaturas');
+  });
+
+  it('should preserve credit type with positive amount for refunds', async () => {
+    mockAnthropicClient.messages.create.mockResolvedValue(
+      makeToolUseResponse(50.0, [
+        {
+          date: '2025-04-20',
+          description: 'ESTORNO PARCIAL',
+          amount: 25.0,
+          type: 'credit',
+          category: 'Outros',
+          subcategory: null,
+          confidence: 0.9,
+        },
+      ]),
+    );
+
+    const result = await service.extract(pdf);
+
+    expect(result.transactions[0].type).toBe('credit');
+    expect(result.transactions[0].amount).toBe(25.0);
+  });
+
+  it('should reject transactions with non-positive amounts', async () => {
+    mockAnthropicClient.messages.create.mockResolvedValue(
+      makeToolUseResponse(100.0, [
+        {
+          date: '2025-04-10',
+          description: 'BAD ENTRY',
+          amount: -50.0,
+          type: 'credit',
+          category: 'Outros',
+          subcategory: null,
+          confidence: 0.5,
+        },
+      ]),
+    );
+
+    await expect(service.extract(pdf)).rejects.toThrow(
+      /amount must be positive/i,
+    );
   });
 
   it('should throw when Claude returns text instead of tool_use', async () => {
@@ -85,6 +141,241 @@ describe('ExtractionService', () => {
       'Unexpected response format from Claude',
     );
   });
+
+  it('should return payments alongside transactions', async () => {
+    mockAnthropicClient.messages.create.mockResolvedValue(
+      makeToolUseResponse(
+        100.0,
+        [
+          {
+            date: '2025-04-10',
+            description: 'UBER *TRIP',
+            amount: 100.0,
+            type: 'debit',
+            category: 'Transporte',
+            subcategory: 'Uber / 99 / Taxi',
+            confidence: 0.95,
+          },
+        ],
+        [
+          {
+            date: '2025-04-05',
+            description: 'PAGTO. POR DEB EM C/C',
+            amount: 1000.0,
+            kind: 'invoice_payment',
+          },
+          {
+            date: '2025-04-05',
+            description: 'SALDO ANTERIOR',
+            amount: 1000.0,
+            kind: 'previous_balance',
+          },
+        ],
+      ),
+    );
+
+    const result = await service.extract(pdf);
+
+    expect(result.payments).toHaveLength(2);
+    expect(result.payments[0]).toEqual({
+      date: '2025-04-05',
+      description: 'PAGTO. POR DEB EM C/C',
+      amount: 1000.0,
+      kind: 'invoice_payment',
+    });
+    expect(result.payments[1].kind).toBe('previous_balance');
+    expect(result.transactions).toHaveLength(1);
+  });
+
+  it('should dedup consecutive duplicate transactions when sum exceeds invoiceTotal', async () => {
+    const dup = {
+      date: '2025-04-10',
+      description: 'CONDOMINIO',
+      amount: 14.0,
+      type: 'debit',
+      category: 'Moradia',
+      subcategory: null,
+      confidence: 0.9,
+    };
+    mockAnthropicClient.messages.create.mockResolvedValue(
+      makeToolUseResponse(14.0, [dup, dup]),
+    );
+
+    const result = await service.extract(pdf);
+
+    expect(result.transactions).toHaveLength(1);
+    expect(result.transactions[0].description).toBe('CONDOMINIO');
+  });
+
+  it('should NOT dedup when sum already matches invoiceTotal', async () => {
+    const sameAmount = (description: string) => ({
+      date: '2025-04-10',
+      description,
+      amount: 14.0,
+      type: 'debit',
+      category: 'Outros',
+      subcategory: null,
+      confidence: 0.9,
+    });
+    mockAnthropicClient.messages.create.mockResolvedValue(
+      makeToolUseResponse(28.0, [sameAmount('UBER'), sameAmount('99 APP')]),
+    );
+
+    const result = await service.extract(pdf);
+
+    expect(result.transactions).toHaveLength(2);
+  });
+
+  it('should move payment-like transactions to payments array (safety net)', async () => {
+    mockAnthropicClient.messages.create.mockResolvedValue(
+      makeToolUseResponse(
+        100.0,
+        [
+          {
+            date: '2025-04-10',
+            description: 'UBER',
+            amount: 100.0,
+            type: 'debit',
+            category: 'Transporte',
+            subcategory: null,
+            confidence: 0.9,
+          },
+          {
+            date: '2025-04-05',
+            description: 'PAGTO. POR DEB EM C/C',
+            amount: 500.0,
+            type: 'credit',
+            category: 'Outros',
+            subcategory: null,
+            confidence: 0.5,
+          },
+          {
+            date: '2025-04-01',
+            description: 'SALDO ANTERIOR',
+            amount: 200.0,
+            type: 'debit',
+            category: 'Outros',
+            subcategory: null,
+            confidence: 0.5,
+          },
+        ],
+        [],
+      ),
+    );
+
+    const result = await service.extract(pdf);
+
+    expect(result.transactions).toHaveLength(1);
+    expect(result.transactions[0].description).toBe('UBER');
+    expect(result.payments).toHaveLength(2);
+    expect(
+      result.payments.find((p) => p.description === 'PAGTO. POR DEB EM C/C')
+        ?.kind,
+    ).toBe('invoice_payment');
+    expect(
+      result.payments.find((p) => p.description === 'SALDO ANTERIOR')?.kind,
+    ).toBe('previous_balance');
+  });
+
+  it('should NOT double-count when payment-like entry is in both arrays', async () => {
+    mockAnthropicClient.messages.create.mockResolvedValue(
+      makeToolUseResponse(
+        100.0,
+        [
+          {
+            date: '2025-04-05',
+            description: 'PAGTO. POR DEB EM C/C',
+            amount: 500.0,
+            type: 'credit',
+            category: 'Outros',
+            subcategory: null,
+            confidence: 0.5,
+          },
+        ],
+        [
+          {
+            date: '2025-04-05',
+            description: 'PAGTO. POR DEB EM C/C',
+            amount: 500.0,
+            kind: 'invoice_payment',
+          },
+        ],
+      ),
+    );
+
+    const result = await service.extract(pdf);
+
+    expect(result.transactions).toHaveLength(0);
+    expect(result.payments).toHaveLength(1);
+  });
+
+  it('should return futureInstallments alongside transactions and payments', async () => {
+    mockAnthropicClient.messages.create.mockResolvedValue(
+      makeToolUseResponse(
+        100.0,
+        [
+          {
+            date: '2025-04-10',
+            description: 'UBER',
+            amount: 100.0,
+            type: 'debit',
+            category: 'Transporte',
+            subcategory: null,
+            confidence: 0.9,
+          },
+        ],
+        [],
+        [
+          {
+            date: '2025-06-25',
+            description: 'LIVELO S.A.',
+            amount: 326.72,
+            installmentInfo: '12/12',
+          },
+        ],
+      ),
+    );
+
+    const result = await service.extract(pdf);
+
+    expect(result.futureInstallments).toHaveLength(1);
+    expect(result.futureInstallments[0]).toEqual({
+      date: '2025-06-25',
+      description: 'LIVELO S.A.',
+      amount: 326.72,
+      installmentInfo: '12/12',
+    });
+    expect(result.transactions).toHaveLength(1);
+  });
+
+  it('uses the complex model (Sonnet) when the bank is Itaú', async () => {
+    mockBankDetector.detect.mockResolvedValue('itau');
+    mockAnthropicClient.messages.create.mockResolvedValue(
+      makeToolUseResponse(0, []),
+    );
+
+    await service.extract(pdf);
+
+    expect(mockAnthropicClient.messages.create).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'claude-sonnet-4-6' }),
+    );
+  });
+
+  it.each(['bradesco', 'nubank', 'other'] as const)(
+    'uses the default model (Haiku) when the bank is %s',
+    async (bank) => {
+      mockBankDetector.detect.mockResolvedValue(bank);
+      mockAnthropicClient.messages.create.mockResolvedValue(
+        makeToolUseResponse(0, []),
+      );
+
+      await service.extract(pdf);
+
+      expect(mockAnthropicClient.messages.create).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'claude-haiku-4-5-20251001' }),
+      );
+    },
+  );
 
   it('should propagate Anthropic SDK errors', async () => {
     mockAnthropicClient.messages.create.mockRejectedValue(

--- a/apps/api/src/extraction/extraction.service.ts
+++ b/apps/api/src/extraction/extraction.service.ts
@@ -1,19 +1,46 @@
 import { Inject, Injectable } from '@nestjs/common';
 import Anthropic from '@anthropic-ai/sdk';
-import { ANTHROPIC_CLIENT, EXTRACTION_MODEL } from './extraction.constants';
-import { ExtractedTransaction } from './extraction.types';
+import {
+  ANTHROPIC_CLIENT,
+  EXTRACTION_MODEL_COMPLEX,
+  EXTRACTION_MODEL_DEFAULT,
+} from './extraction.constants';
+import {
+  ExtractedFutureInstallment,
+  ExtractedPayment,
+  ExtractedTransaction,
+} from './extraction.types';
+import { BankDetectorService } from './bank-detector.service';
+
+interface ClaudeTransaction {
+  date: string;
+  description: string;
+  amount: number;
+  type: 'debit' | 'credit';
+  category: string;
+  subcategory: string | null;
+  confidence: number;
+}
+
+interface ClaudePayment {
+  date: string;
+  description: string;
+  amount: number;
+  kind: 'invoice_payment' | 'previous_balance';
+}
+
+interface ClaudeFutureInstallment {
+  date: string;
+  description: string;
+  amount: number;
+  installmentInfo: string | null;
+}
 
 interface ClaudeExtractionResult {
   invoiceTotal: number;
-  transactions: Array<{
-    date: string;
-    description: string;
-    amount: number;
-    type: 'debit' | 'credit';
-    category: string;
-    subcategory: string | null;
-    confidence: number;
-  }>;
+  transactions: ClaudeTransaction[];
+  payments?: ClaudePayment[];
+  futureInstallments?: ClaudeFutureInstallment[];
 }
 
 const EXTRACTION_TOOL: Anthropic.Tool = {
@@ -24,10 +51,13 @@ const EXTRACTION_TOOL: Anthropic.Tool = {
     properties: {
       invoiceTotal: {
         type: 'number',
-        description: 'Total amount due on the invoice',
+        description:
+          'Total of purchases in the current billing period (NOT "Total a pagar" or net amount due). For Itaú: "Total dos lançamentos atuais". For Nubank: "Total de compras de todos os cartões" plus "IOF de compras internacionais". For Bradesco: sum of all purchases shown.',
       },
       transactions: {
         type: 'array',
+        description:
+          'Purchases made by the cardholder during the current billing period (and refunds/estornos). Do NOT include invoice payments or previous-period balances here — put those in `payments`.',
         items: {
           type: 'object',
           properties: {
@@ -71,18 +101,171 @@ const EXTRACTION_TOOL: Anthropic.Tool = {
           ],
         },
       },
+      payments: {
+        type: 'array',
+        description:
+          'Invoice payments and previous-period balances — NOT purchase transactions. Includes: "PAGTO. POR DEB EM C/C", "PAGAMENTO DEB AUTOMATIC", "Pagamento recebido", "Pagamento em DD MMM", "SALDO ANTERIOR", "Fatura anterior", "Saldo restante da fatura anterior".',
+        items: {
+          type: 'object',
+          properties: {
+            date: { type: 'string', description: 'YYYY-MM-DD' },
+            description: { type: 'string' },
+            amount: { type: 'number', description: 'Positive amount' },
+            kind: {
+              type: 'string',
+              enum: ['invoice_payment', 'previous_balance'],
+              description:
+                '`invoice_payment` for payments of the card invoice; `previous_balance` for carry-over balances.',
+            },
+          },
+          required: ['date', 'description', 'amount', 'kind'],
+        },
+      },
+      futureInstallments: {
+        type: 'array',
+        description:
+          'Installments scheduled for FUTURE billing periods. These are listed in dedicated sections such as "Compras parceladas - próximas faturas" (Itaú), "Próxima fatura", "Demais faturas", "Total para próximas faturas". They will be charged in subsequent invoices — they are NOT part of the current invoice total.',
+        items: {
+          type: 'object',
+          properties: {
+            date: {
+              type: 'string',
+              description: 'Original purchase date (YYYY-MM-DD)',
+            },
+            description: { type: 'string' },
+            amount: {
+              type: 'number',
+              description: 'Positive amount of the future installment',
+            },
+            installmentInfo: {
+              type: ['string', 'null'],
+              description:
+                'Installment notation if present, e.g. "12/12" or "02/06"',
+            },
+          },
+          required: ['date', 'description', 'amount', 'installmentInfo'],
+        },
+      },
     },
-    required: ['invoiceTotal', 'transactions'],
+    required: [
+      'invoiceTotal',
+      'transactions',
+      'payments',
+      'futureInstallments',
+    ],
   },
 };
 
+const EXTRACTION_PROMPT = `Extract every entry from this credit card invoice (fatura) into THREE buckets. Every line in the PDF belongs to exactly ONE bucket — never to multiple, never to none.
+
+BUCKET 1 — \`transactions\` (purchase transactions in the current period)
+- Every line representing a purchase made by the cardholder during the current billing period.
+- Current installment of split purchases (e.g. "12/03 SMILES FIDEL*CAR 02/05 157,41" — installment 2 of 5 charged this period).
+- IOF lines tied to international purchases (spending in this period).
+- Refunds / estornos / créditos: type "credit" with a POSITIVE amount.
+
+BUCKET 2 — \`payments\` (invoice payments + previous balances, NOT purchases)
+- Invoice payments → kind: "invoice_payment":
+  - "PAGTO. POR DEB EM C/C" (Bradesco)
+  - "PAGAMENTO DEB AUTOMATIC" / "PAGAMENTO EFETUADO" (Itaú)
+  - "Pagamento recebido" / "Pagamento em DD MMM" (Nubank)
+- Previous-period balances → kind: "previous_balance":
+  - "SALDO ANTERIOR" (Bradesco)
+  - "Fatura anterior" / "Saldo restante da fatura anterior" (Nubank)
+  - "Total da fatura anterior" / "Pagamento efetuado em" (Itaú resumo)
+
+BUCKET 3 — \`futureInstallments\` (will be charged in next invoices, NOT this one)
+- Look for sections labeled "Compras parceladas - próximas faturas" (Itaú), or any section with the heading "Próxima fatura", "Demais faturas", "Total para próximas faturas".
+- ITAÚ LAYOUT: this section is a separate table that follows the current-period transactions. Its lines look identical in format to current installments (date + description + XX/YY + value) — distinguish ONLY by which section they appear under.
+- Every row in this section goes to \`futureInstallments\`, NEVER to \`transactions\`.
+
+INVOICE TOTAL
+Return invoiceTotal as the SUM OF PURCHASES IN THE CURRENT PERIOD.
+- Itaú: read "Total dos lançamentos atuais".
+- Nubank: "Total de compras de todos os cartões" + "IOF de compras internacionais". DO NOT use "Total a pagar" — it is net of payments.
+- Bradesco: read "Total para: <name>" at the bottom of the statement, when present.
+
+AMOUNTS
+- amount must always be POSITIVE in all three arrays.
+- For transactions: direction is conveyed by type ("debit" for purchases, "credit" for refunds/estornos).
+
+SELF-CHECK BEFORE RETURNING
+After populating the three buckets, verify:
+1. sum(debits − credits) of items in \`transactions\` ≈ invoiceTotal (within R$ 0,01).
+2. If they differ by more than R$ 1, you likely misclassified some entries. Common mistakes:
+   - Rows from "Compras parceladas - próximas faturas" leaked into \`transactions\` (move them to \`futureInstallments\`).
+   - "SALDO ANTERIOR" / "Fatura anterior" / payment rows leaked into \`transactions\` (move them to \`payments\`).
+   - Page-break duplicates (same date + description + amount appearing twice consecutively in the PDF).
+Review and correct before producing the final answer.`;
+
+const PAYMENT_PATTERNS: Array<{
+  regex: RegExp;
+  kind: ExtractedPayment['kind'];
+}> = [
+  { regex: /pagto\.?\s*por\s*deb/i, kind: 'invoice_payment' },
+  { regex: /pagamento\s+deb\s+automatic/i, kind: 'invoice_payment' },
+  { regex: /pagamento\s+efetuado/i, kind: 'invoice_payment' },
+  { regex: /pagamento\s+(recebido|em\s+\d)/i, kind: 'invoice_payment' },
+  { regex: /saldo\s+anterior/i, kind: 'previous_balance' },
+  { regex: /fatura\s+anterior/i, kind: 'previous_balance' },
+  {
+    regex: /saldo\s+restante\s+da\s+fatura\s+anterior/i,
+    kind: 'previous_balance',
+  },
+];
+
+function matchPaymentKind(
+  description: string,
+): ExtractedPayment['kind'] | null {
+  for (const p of PAYMENT_PATTERNS) {
+    if (p.regex.test(description)) return p.kind;
+  }
+  return null;
+}
+
+function sumNet(transactions: ExtractedTransaction[]): number {
+  return transactions.reduce(
+    (acc, t) => acc + (t.type === 'credit' ? -t.amount : t.amount),
+    0,
+  );
+}
+
+function dedupConsecutiveDuplicates(
+  transactions: ExtractedTransaction[],
+): ExtractedTransaction[] {
+  const out: ExtractedTransaction[] = [];
+  for (const t of transactions) {
+    const prev = out[out.length - 1];
+    const isDup =
+      prev &&
+      prev.date === t.date &&
+      prev.description === t.description &&
+      prev.amount === t.amount &&
+      prev.type === t.type;
+    if (!isDup) out.push(t);
+  }
+  return out;
+}
+
 @Injectable()
 export class ExtractionService {
-  constructor(@Inject(ANTHROPIC_CLIENT) private readonly client: Anthropic) {}
+  constructor(
+    @Inject(ANTHROPIC_CLIENT) private readonly client: Anthropic,
+    private readonly bankDetector: BankDetectorService,
+  ) {}
 
-  async extract(pdf: Buffer): Promise<ExtractedTransaction[]> {
+  async extract(pdf: Buffer): Promise<{
+    invoiceTotal: number;
+    transactions: ExtractedTransaction[];
+    payments: ExtractedPayment[];
+    futureInstallments: ExtractedFutureInstallment[];
+  }> {
+    const bank = await this.bankDetector.detect(pdf);
+    const model =
+      bank === 'itau' ? EXTRACTION_MODEL_COMPLEX : EXTRACTION_MODEL_DEFAULT;
+
     const response = await this.client.messages.create({
-      model: EXTRACTION_MODEL,
+      model,
       max_tokens: 16000,
       tools: [EXTRACTION_TOOL],
       tool_choice: { type: 'tool', name: 'extract_transactions' },
@@ -98,10 +281,7 @@ export class ExtractionService {
                 data: pdf.toString('base64'),
               },
             },
-            {
-              type: 'text',
-              text: 'Extract all transactions from this credit card invoice. Include every line item. Do NOT include any entry labeled "SALDO ANTERIOR" — it is a carried-over balance from a previous period, not a transaction.',
-            },
+            { type: 'text', text: EXTRACTION_PROMPT },
           ],
         },
       ],
@@ -122,14 +302,74 @@ export class ExtractionService {
       );
     }
 
-    return result.transactions.map((t) => ({
-      date: t.date,
-      description: t.description,
-      amount: t.amount,
-      type: t.type,
-      category: t.category,
-      subcategory: t.subcategory,
-      confidence: t.confidence,
+    for (const t of result.transactions) {
+      if (!(t.amount > 0)) {
+        throw new Error(
+          `Claude returned a transaction with non-positive amount: ${JSON.stringify(t)}. amount must be positive (direction is conveyed by type).`,
+        );
+      }
+    }
+
+    const initialTransactions: ExtractedTransaction[] = result.transactions.map(
+      (t) => ({
+        date: t.date,
+        description: t.description,
+        amount: t.amount,
+        type: t.type,
+        category: t.category,
+        subcategory: t.subcategory,
+        confidence: t.confidence,
+      }),
+    );
+
+    const payments: ExtractedPayment[] = (result.payments ?? []).map((p) => ({
+      date: p.date,
+      description: p.description,
+      amount: p.amount,
+      kind: p.kind,
     }));
+
+    let transactions: ExtractedTransaction[] = [];
+    for (const t of initialTransactions) {
+      const kind = matchPaymentKind(t.description);
+      if (kind) {
+        const alreadyInPayments = payments.some(
+          (p) =>
+            p.date === t.date &&
+            p.description === t.description &&
+            p.amount === t.amount,
+        );
+        if (!alreadyInPayments) {
+          payments.push({
+            date: t.date,
+            description: t.description,
+            amount: t.amount,
+            kind,
+          });
+        }
+      } else {
+        transactions.push(t);
+      }
+    }
+
+    if (Math.abs(sumNet(transactions) - result.invoiceTotal) > 0.01) {
+      transactions = dedupConsecutiveDuplicates(transactions);
+    }
+
+    const futureInstallments: ExtractedFutureInstallment[] = (
+      result.futureInstallments ?? []
+    ).map((f) => ({
+      date: f.date,
+      description: f.description,
+      amount: f.amount,
+      installmentInfo: f.installmentInfo,
+    }));
+
+    return {
+      invoiceTotal: result.invoiceTotal,
+      transactions,
+      payments,
+      futureInstallments,
+    };
   }
 }

--- a/apps/api/src/extraction/extraction.types.ts
+++ b/apps/api/src/extraction/extraction.types.ts
@@ -7,3 +7,17 @@ export interface ExtractedTransaction {
   subcategory: string | null;
   confidence: number;
 }
+
+export interface ExtractedPayment {
+  date: string;
+  description: string;
+  amount: number;
+  kind: 'invoice_payment' | 'previous_balance';
+}
+
+export interface ExtractedFutureInstallment {
+  date: string;
+  description: string;
+  amount: number;
+  installmentInfo: string | null;
+}

--- a/apps/api/src/invoices/invoices.repository.ts
+++ b/apps/api/src/invoices/invoices.repository.ts
@@ -11,7 +11,9 @@ interface CreateInvoiceData {
 }
 
 export type InvoiceWithTransactions = Invoice & { transactions: Transaction[] };
-export type InvoiceWithDebits = Invoice & { transactions: { amount: Decimal }[] };
+export type InvoiceWithDebits = Invoice & {
+  transactions: { amount: Decimal }[];
+};
 
 @Injectable()
 export class InvoicesRepository {
@@ -25,7 +27,9 @@ export class InvoicesRepository {
     return this.prisma.invoice.findFirst({ where: { id, userId } });
   }
 
-  async findAllByUserIdWithDebits(userId: string): Promise<InvoiceWithDebits[]> {
+  async findAllByUserIdWithDebits(
+    userId: string,
+  ): Promise<InvoiceWithDebits[]> {
     return this.prisma.invoice.findMany({
       where: { userId },
       orderBy: { createdAt: 'desc' },

--- a/apps/api/src/invoices/invoices.service.spec.ts
+++ b/apps/api/src/invoices/invoices.service.spec.ts
@@ -207,7 +207,9 @@ describe('InvoicesService', () => {
       const invoices = [
         { id: 'inv-1', userId: 'user-1', transactions: [{ amount: '150.00' }] },
       ];
-      mockInvoicesRepository.findAllByUserIdWithDebits.mockResolvedValue(invoices);
+      mockInvoicesRepository.findAllByUserIdWithDebits.mockResolvedValue(
+        invoices,
+      );
 
       const result = await service.findAll('user-1');
 

--- a/apps/api/src/transactions/transactions.listener.spec.ts
+++ b/apps/api/src/transactions/transactions.listener.spec.ts
@@ -63,7 +63,12 @@ describe('TransactionsListener', () => {
 
   it('should download PDF, extract transactions, classify them, save them and mark invoice as DONE', async () => {
     mockStorageService.download.mockResolvedValue(pdfBuffer);
-    mockExtractionService.extract.mockResolvedValue(extracted);
+    mockExtractionService.extract.mockResolvedValue({
+      invoiceTotal: 45.9,
+      transactions: extracted,
+      payments: [],
+      futureInstallments: [],
+    });
     mockCategorizationService.classifyMany.mockResolvedValue([classified]);
 
     await listener.handleInvoiceCreated(event);

--- a/apps/api/src/transactions/transactions.listener.ts
+++ b/apps/api/src/transactions/transactions.listener.ts
@@ -28,7 +28,8 @@ export class TransactionsListener {
         INVOICES_BUCKET,
         event.storagePath,
       );
-      const extracted = await this.extractionService.extract(pdf);
+      const { transactions: extracted } =
+        await this.extractionService.extract(pdf);
       const classifications =
         await this.categorizationService.classifyMany(extracted);
       const transactions = extracted.map((t, i) => ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       class-validator:
         specifier: ^0.15.1
         version: 0.15.1
+      pdf-parse:
+        specifier: ^2.4.5
+        version: 2.4.5
       prisma:
         specifier: ^6.19.3
         version: 6.19.3(typescript@5.9.3)
@@ -189,7 +192,7 @@ importers:
         version: 15.3.9(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3))
+        version: 30.3.0(@types/node@20.19.39)
       jest-environment-jsdom:
         specifier: ^30.3.0
         version: 30.3.0
@@ -198,7 +201,7 @@ importers:
         version: 4.2.2
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@20.19.39))(typescript@5.9.3)
       typescript:
         specifier: ^5
         version: 5.9.3
@@ -1008,6 +1011,75 @@ packages:
   '@lukeed/csprng@1.1.0':
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
+
+  '@napi-rs/canvas-android-arm64@0.1.80':
+    resolution: {integrity: sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@0.1.80':
+    resolution: {integrity: sha512-O64APRTXRUiAz0P8gErkfEr3lipLJgM6pjATwavZ22ebhjYl/SUbpgM0xcWPQBNMP1n29afAC/Us5PX1vg+JNQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@0.1.80':
+    resolution: {integrity: sha512-FqqSU7qFce0Cp3pwnTjVkKjjOtxMqRe6lmINxpIZYaZNnVI0H5FtsaraZJ36SiTHNjZlUB69/HhxNDT1Aaa9vA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.80':
+    resolution: {integrity: sha512-eyWz0ddBDQc7/JbAtY4OtZ5SpK8tR4JsCYEZjCE3dI8pqoWUC8oMwYSBGCYfsx2w47cQgQCgMVRVTFiiO38hHQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.80':
+    resolution: {integrity: sha512-qwA63t8A86bnxhuA/GwOkK3jvb+XTQaTiVML0vAWoHyoZYTjNs7BzoOONDgTnNtr8/yHrq64XXzUoLqDzU+Uuw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.80':
+    resolution: {integrity: sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.80':
+    resolution: {integrity: sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.80':
+    resolution: {integrity: sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.80':
+    resolution: {integrity: sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.80':
+    resolution: {integrity: sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@0.1.80':
+    resolution: {integrity: sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -3915,6 +3987,15 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pdf-parse@2.4.5:
+    resolution: {integrity: sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg==}
+    engines: {node: '>=20.16.0 <21 || >=22.3.0'}
+    hasBin: true
+
+  pdfjs-dist@5.4.296:
+    resolution: {integrity: sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==}
+    engines: {node: '>=20.16.0 || >=22.3.0'}
+
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
@@ -5527,41 +5608,6 @@ snapshots:
       jest-util: 30.3.0
       slash: 3.0.0
 
-  '@jest/core@30.3.0(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3))':
-    dependencies:
-      '@jest/console': 30.3.0
-      '@jest/pattern': 30.0.1
-      '@jest/reporters': 30.3.0
-      '@jest/test-result': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
-      '@types/node': 22.19.17
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      exit-x: 0.2.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@22.19.17)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3))
-      jest-haste-map: 30.3.0
-      jest-message-util: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-resolve-dependencies: 30.3.0
-      jest-runner: 30.3.0
-      jest-runtime: 30.3.0
-      jest-snapshot: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      jest-watcher: 30.3.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
   '@jest/core@30.3.0(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 30.3.0
@@ -5771,6 +5817,49 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@lukeed/csprng@1.1.0': {}
+
+  '@napi-rs/canvas-android-arm64@0.1.80':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@0.1.80':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@0.1.80':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.80':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.80':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.80':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.80':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.80':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.80':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.80':
+    optional: true
+
+  '@napi-rs/canvas@0.1.80':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 0.1.80
+      '@napi-rs/canvas-darwin-arm64': 0.1.80
+      '@napi-rs/canvas-darwin-x64': 0.1.80
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.80
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.80
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.80
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.80
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.80
+      '@napi-rs/canvas-linux-x64-musl': 0.1.80
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.80
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -7370,8 +7459,8 @@ snapshots:
       '@typescript-eslint/parser': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.4(jiti@2.6.1))
@@ -7394,7 +7483,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -7405,22 +7494,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7431,7 +7520,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -8220,15 +8309,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.3.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3)):
+  jest-cli@30.3.0(@types/node@20.19.39):
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3))
+      jest-config: 30.3.0(@types/node@20.19.39)
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -8258,7 +8347,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.3.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3)):
+  jest-config@30.3.0(@types/node@20.19.39):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -8285,39 +8374,6 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.19.39
-      ts-node: 10.9.2(@types/node@20.19.39)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@30.3.0(@types/node@22.19.17)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.3.0
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-runner: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      parse-json: 5.2.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.19.17
-      ts-node: 10.9.2(@types/node@20.19.39)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -8585,12 +8641,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.3.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3)):
+  jest@30.3.0(@types/node@20.19.39):
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
       '@jest/types': 30.3.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3))
+      jest-cli: 30.3.0(@types/node@20.19.39)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -9095,6 +9151,15 @@ snapshots:
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
+
+  pdf-parse@2.4.5:
+    dependencies:
+      '@napi-rs/canvas': 0.1.80
+      pdfjs-dist: 5.4.296
+
+  pdfjs-dist@5.4.296:
+    optionalDependencies:
+      '@napi-rs/canvas': 0.1.80
 
   perfect-debounce@1.0.0: {}
 
@@ -9762,12 +9827,12 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-jest@29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@20.19.39))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.3.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3))
+      jest: 30.3.0(@types/node@20.19.39)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -9811,25 +9876,6 @@ snapshots:
       source-map: 0.7.6
       typescript: 5.9.3
       webpack: 5.106.0
-
-  ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.39
-      acorn: 8.16.0
-      acorn-walk: 8.3.5
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 5.9.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
 
   ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## Summary

- Schema da extração passa a ter **3 buckets**: `transactions` (compras + estornos), `payments` (pagamentos da fatura + saldos anteriores) e `futureInstallments` (parcelas que ainda vão cair). O Claude para de "espremer" tudo em `transactions` quando tem outras caixas onde caber.
- Prompt reformulado com **self-check matemático** no final: a LLM revisa se `sum(debits − credits) == invoiceTotal` antes de retornar.
- `BankDetectorService` identifica banco via texto da primeira página (pdf-parse). **Itaú usa Sonnet 4.6** (layout multi-cartão + seção "próximas faturas" exige mais raciocínio); Bradesco/Nubank/outros seguem com Haiku 4.5.
- **Safety net pós-extração**: descrições matching `PAGTO`, `SALDO ANTERIOR`, `Pagamento em`, etc. são movidas pra `payments` mesmo se a LLM esquecer. Dedup consecutivo quando soma diverge do invoiceTotal (resolve duplicatas de page-break).
- `amount` validado como sempre positivo. Estornos: `type: 'credit'`.
- **Integration spec novo** com chamadas reais à API, skipped por padrão. Roda com `RUN_EXTRACTION_INTEGRATION=1 pnpm test extraction.service.integration`.

Listener apenas consome `transactions` por ora — `payments` e `futureInstallments` ficam disponíveis pra UI futura (sem persistência ainda).

**Custo:** ~$5/mês com 20% de faturas Itaú (vs ~$3 todo Haiku, ~$10 todo Sonnet).

## Test plan

- [x] `pnpm test` — 156 unit tests passando (24 suites)
- [x] `pnpm typecheck` ✓
- [x] `pnpm lint` ✓
- [x] Integration spec validado manualmente contra 4 PDFs reais (Itaú × 2, Nubank, Bradesco) — passou nos pontos centrais (3 buckets povoados, sem padrões de exclusão, amounts positivos)
- [ ] Validar end-to-end em ambiente local: upload de fatura Itaú real e conferir que `transactions` não contém mais parcelas futuras nem pagamentos
- [ ] Validar que faturas Bradesco/Nubank continuam sendo processadas corretamente
- [ ] Conferir que latência de extração ainda é aceitável (Sonnet ~50-90s pra Itaú)

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)