### PR TITLE
feat(extraction): detectar billingMonth automaticamente da fatura

### DIFF
--- a/apps/api/prisma/migrations/20260615000000_make_billing_month_nullable/migration.sql
+++ b/apps/api/prisma/migrations/20260615000000_make_billing_month_nullable/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Invoice" ALTER COLUMN "billingMonth" DROP NOT NULL;
+ALTER TABLE "Invoice" ALTER COLUMN "billingMonth" DROP DEFAULT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -23,7 +23,7 @@ model Invoice {
   filename     String
   storagePath  String
   status       InvoiceStatus @default(PENDING)
-  billingMonth DateTime
+  billingMonth DateTime?
   createdAt    DateTime      @default(now())
   transactions Transaction[]
 }

--- a/apps/api/src/extraction/extraction.service.integration.spec.ts
+++ b/apps/api/src/extraction/extraction.service.integration.spec.ts
@@ -29,6 +29,7 @@ const EXCLUSION_PATTERNS = [
 interface ExpectedCase {
   file: string;
   expectedTotal: number;
+  expectedBillingMonth: string;
   label: string;
   expectPayments: boolean;
   expectFutureInstallments: boolean;
@@ -67,6 +68,7 @@ describeIf('ExtractionService (integration)', () => {
     {
       file: 'itau-humberto.pdf',
       expectedTotal: 18918.07,
+      expectedBillingMonth: '2026-05',
       label: 'Itaú Humberto',
       expectPayments: true,
       expectFutureInstallments: true,
@@ -74,13 +76,15 @@ describeIf('ExtractionService (integration)', () => {
     {
       file: 'Nubank_2026-05-18.pdf',
       expectedTotal: 1138.35,
+      expectedBillingMonth: '2026-05',
       label: 'Nubank',
       expectPayments: true,
       expectFutureInstallments: false,
     },
     {
-      file: 'Bradesco_ExtratoFaturaAberta-23-05-2026-compactado.pdf',
-      expectedTotal: 3992.33,
+      file: 'bradesco-final-mai.pdf',
+      expectedTotal: 4356.38,
+      expectedBillingMonth: '2026-05',
       label: 'Bradesco',
       expectPayments: true,
       expectFutureInstallments: false,
@@ -99,6 +103,10 @@ describeIf('ExtractionService (integration)', () => {
       it('invoiceTotal and sum match (±R$ 0,01)', () => {
         expect(result.invoiceTotal).toBeCloseTo(c.expectedTotal, 2);
         expect(sumNet(result.transactions)).toBeCloseTo(c.expectedTotal, 2);
+      });
+
+      it(`billingMonth matches ${c.expectedBillingMonth}`, () => {
+        expect(result.billingMonth).toBe(c.expectedBillingMonth);
       });
 
       it('no excluded patterns in descriptions', () => {

--- a/apps/api/src/extraction/extraction.service.integration.spec.ts
+++ b/apps/api/src/extraction/extraction.service.integration.spec.ts
@@ -84,7 +84,7 @@ describeIf('ExtractionService (integration)', () => {
     {
       file: 'bradesco-final-mai.pdf',
       expectedTotal: 4356.38,
-      expectedBillingMonth: '2026-05',
+      expectedBillingMonth: '2026-06',
       label: 'Bradesco',
       expectPayments: true,
       expectFutureInstallments: false,

--- a/apps/api/src/extraction/extraction.service.spec.ts
+++ b/apps/api/src/extraction/extraction.service.spec.ts
@@ -13,6 +13,7 @@ function makeToolUseResponse(
   transactions: object[],
   payments: object[] = [],
   futureInstallments: object[] = [],
+  billingMonth: string = '2025-04',
 ) {
   return {
     content: [
@@ -23,6 +24,7 @@ function makeToolUseResponse(
           transactions,
           payments,
           futureInstallments,
+          billingMonth,
         },
       },
     ],
@@ -384,4 +386,52 @@ describe('ExtractionService', () => {
 
     await expect(service.extract(pdf)).rejects.toThrow('API error');
   });
+
+  it('should return billingMonth alongside the other buckets', async () => {
+    mockAnthropicClient.messages.create.mockResolvedValue(
+      makeToolUseResponse(0, [], [], [], '2026-05'),
+    );
+
+    const result = await service.extract(pdf);
+
+    expect(result.billingMonth).toBe('2026-05');
+  });
+
+  it('should throw when Claude does not return billingMonth', async () => {
+    mockAnthropicClient.messages.create.mockResolvedValue({
+      content: [
+        {
+          type: 'tool_use',
+          input: {
+            invoiceTotal: 0,
+            transactions: [],
+            payments: [],
+            futureInstallments: [],
+          },
+        },
+      ],
+    });
+
+    await expect(service.extract(pdf)).rejects.toThrow(/billingMonth/i);
+  });
+
+  it.each([
+    '05/2026',
+    '2026/05',
+    '2026-13',
+    '2026-00',
+    '26-05',
+    '2026-05-15',
+    'maio 2026',
+    '',
+  ])(
+    'should throw when Claude returns invalid billingMonth format: %p',
+    async (badFormat) => {
+      mockAnthropicClient.messages.create.mockResolvedValue(
+        makeToolUseResponse(0, [], [], [], badFormat),
+      );
+
+      await expect(service.extract(pdf)).rejects.toThrow(/billingMonth/i);
+    },
+  );
 });

--- a/apps/api/src/extraction/extraction.service.ts
+++ b/apps/api/src/extraction/extraction.service.ts
@@ -9,6 +9,7 @@ import {
   ExtractedFutureInstallment,
   ExtractedPayment,
   ExtractedTransaction,
+  ExtractionResult,
 } from './extraction.types';
 import { BankDetectorService } from './bank-detector.service';
 
@@ -38,10 +39,13 @@ interface ClaudeFutureInstallment {
 
 interface ClaudeExtractionResult {
   invoiceTotal: number;
+  billingMonth: string;
   transactions: ClaudeTransaction[];
   payments?: ClaudePayment[];
   futureInstallments?: ClaudeFutureInstallment[];
 }
+
+const BILLING_MONTH_REGEX = /^\d{4}-(0[1-9]|1[0-2])$/;
 
 const EXTRACTION_TOOL: Anthropic.Tool = {
   name: 'extract_transactions',
@@ -53,6 +57,11 @@ const EXTRACTION_TOOL: Anthropic.Tool = {
         type: 'number',
         description:
           'Total of purchases in the current billing period (NOT "Total a pagar" or net amount due). For Itaú: "Total dos lançamentos atuais". For Nubank: "Total de compras de todos os cartões" plus "IOF de compras internacionais". For Bradesco: sum of all purchases shown.',
+      },
+      billingMonth: {
+        type: 'string',
+        description:
+          'Billing month of this invoice in format YYYY-MM (zero-padded), taken from the invoice due date / vencimento. Examples: "2026-05" for an invoice due in May 2026. Read from the prominent due-date field on the invoice header (Itaú "Vencimento", Nubank "Vencimento da fatura", Bradesco "Data do vencimento"). NEVER infer from transaction dates.',
       },
       transactions: {
         type: 'array',
@@ -149,6 +158,7 @@ const EXTRACTION_TOOL: Anthropic.Tool = {
     },
     required: [
       'invoiceTotal',
+      'billingMonth',
       'transactions',
       'payments',
       'futureInstallments',
@@ -184,6 +194,13 @@ Return invoiceTotal as the SUM OF PURCHASES IN THE CURRENT PERIOD.
 - Itaú: read "Total dos lançamentos atuais".
 - Nubank: "Total de compras de todos os cartões" + "IOF de compras internacionais". DO NOT use "Total a pagar" — it is net of payments.
 - Bradesco: read "Total para: <name>" at the bottom of the statement, when present.
+
+BILLING MONTH
+Return billingMonth as the month of the invoice's DUE DATE (vencimento), in format YYYY-MM (zero-padded month).
+- Itaú: "Vencimento" on the header (e.g. "05/05/2026" → "2026-05").
+- Nubank: "Vencimento da fatura" or "Vence em".
+- Bradesco: "Data do vencimento".
+NEVER derive billingMonth from transaction dates. Only use the explicit due-date field.
 
 AMOUNTS
 - amount must always be POSITIVE in all three arrays.
@@ -254,12 +271,7 @@ export class ExtractionService {
     private readonly bankDetector: BankDetectorService,
   ) {}
 
-  async extract(pdf: Buffer): Promise<{
-    invoiceTotal: number;
-    transactions: ExtractedTransaction[];
-    payments: ExtractedPayment[];
-    futureInstallments: ExtractedFutureInstallment[];
-  }> {
+  async extract(pdf: Buffer): Promise<ExtractionResult> {
     const bank = await this.bankDetector.detect(pdf);
     const model =
       bank === 'itau' ? EXTRACTION_MODEL_COMPLEX : EXTRACTION_MODEL_DEFAULT;
@@ -299,6 +311,17 @@ export class ExtractionService {
     if (!Array.isArray(result.transactions)) {
       throw new Error(
         `Claude returned malformed extraction result: ${JSON.stringify(result)}`,
+      );
+    }
+
+    if (
+      typeof result.billingMonth !== 'string' ||
+      !BILLING_MONTH_REGEX.test(result.billingMonth)
+    ) {
+      throw new Error(
+        `Claude returned invalid billingMonth (expected "YYYY-MM"): ${JSON.stringify(
+          result.billingMonth,
+        )}`,
       );
     }
 
@@ -367,6 +390,7 @@ export class ExtractionService {
 
     return {
       invoiceTotal: result.invoiceTotal,
+      billingMonth: result.billingMonth,
       transactions,
       payments,
       futureInstallments,

--- a/apps/api/src/extraction/extraction.types.ts
+++ b/apps/api/src/extraction/extraction.types.ts
@@ -21,3 +21,11 @@ export interface ExtractedFutureInstallment {
   amount: number;
   installmentInfo: string | null;
 }
+
+export interface ExtractionResult {
+  invoiceTotal: number;
+  billingMonth: string;
+  transactions: ExtractedTransaction[];
+  payments: ExtractedPayment[];
+  futureInstallments: ExtractedFutureInstallment[];
+}

--- a/apps/api/src/invoices/dto/create-invoice.dto.ts
+++ b/apps/api/src/invoices/dto/create-invoice.dto.ts
@@ -1,7 +1,10 @@
-import { IsDateString, IsNotEmpty } from 'class-validator';
+import { IsDateString, IsOptional } from 'class-validator';
 
 export class CreateInvoiceDto {
-  @IsNotEmpty()
+  // Kept for backward compatibility with the MVP front-end, which still
+  // sends this value. The backend ignores it — `billingMonth` is now
+  // extracted from the invoice PDF itself by the listener.
+  @IsOptional()
   @IsDateString()
-  billingMonth: string;
+  billingMonth?: string;
 }

--- a/apps/api/src/invoices/dto/invoice-detail-response.dto.spec.ts
+++ b/apps/api/src/invoices/dto/invoice-detail-response.dto.spec.ts
@@ -33,4 +33,12 @@ describe('InvoiceDetailResponseDto.from', () => {
     const dto = InvoiceDetailResponseDto.from(base);
     expect(dto.billingMonth).toEqual(new Date('2025-09-01'));
   });
+
+  it('forwards null billingMonth (invoice still PENDING)', () => {
+    const dto = InvoiceDetailResponseDto.from({
+      ...base,
+      billingMonth: null as unknown as Date,
+    });
+    expect(dto.billingMonth).toBeNull();
+  });
 });

--- a/apps/api/src/invoices/dto/invoice-detail-response.dto.ts
+++ b/apps/api/src/invoices/dto/invoice-detail-response.dto.ts
@@ -33,7 +33,7 @@ export class InvoiceDetailResponseDto {
   id: string;
   filename: string;
   status: string;
-  billingMonth: Date;
+  billingMonth: Date | null;
   transactions: TransactionDto[];
 
   static from(invoice: InvoiceWithTransactions): InvoiceDetailResponseDto {

--- a/apps/api/src/invoices/dto/invoice-response.dto.spec.ts
+++ b/apps/api/src/invoices/dto/invoice-response.dto.spec.ts
@@ -23,6 +23,15 @@ describe('InvoiceResponseDto.from', () => {
     expect(dto.billingMonth).toEqual(new Date('2025-09-01'));
   });
 
+  it('forwards null billingMonth (invoice still PENDING)', () => {
+    const dto = InvoiceResponseDto.from({
+      ...base,
+      billingMonth: null,
+      transactions: [],
+    });
+    expect(dto.billingMonth).toBeNull();
+  });
+
   it('excludes createdAt', () => {
     const dto = InvoiceResponseDto.from({ ...base, transactions: [] });
     expect(

--- a/apps/api/src/invoices/dto/invoice-response.dto.ts
+++ b/apps/api/src/invoices/dto/invoice-response.dto.ts
@@ -4,7 +4,7 @@ export class InvoiceResponseDto {
   id: string;
   filename: string;
   status: string;
-  billingMonth: Date;
+  billingMonth: Date | null;
   total: number;
 
   static from(invoice: InvoiceWithDebits): InvoiceResponseDto {

--- a/apps/api/src/invoices/invoices.controller.spec.ts
+++ b/apps/api/src/invoices/invoices.controller.spec.ts
@@ -11,9 +11,7 @@ const mockInvoicesService = {
   delete: jest.fn(),
 };
 
-const billingMonthDto: CreateInvoiceDto = {
-  billingMonth: '2025-09-01T00:00:00.000Z',
-};
+const emptyDto: CreateInvoiceDto = {};
 
 describe('InvoicesController', () => {
   let controller: InvoicesController;
@@ -37,20 +35,29 @@ describe('InvoicesController', () => {
       size: 1024,
     } as Express.Multer.File;
 
-    it('should return invoiceId for a valid PDF', async () => {
+    it('should return invoiceId for a valid PDF without any billingMonth in the body', async () => {
       mockInvoicesService.create.mockResolvedValue({ invoiceId: 'inv-1' });
 
-      const result = await controller.create(
-        'user-1',
-        pdfFile,
-        billingMonthDto,
-      );
+      const result = await controller.create('user-1', pdfFile, emptyDto);
 
       expect(result).toEqual({ invoiceId: 'inv-1' });
       expect(mockInvoicesService.create).toHaveBeenCalledWith(
         'user-1',
         pdfFile,
-        new Date('2025-09-01T00:00:00.000Z'),
+        undefined,
+      );
+    });
+
+    it('should ignore billingMonth if the legacy MVP body still sends it', async () => {
+      mockInvoicesService.create.mockResolvedValue({ invoiceId: 'inv-1' });
+
+      await controller.create('user-1', pdfFile, {
+        billingMonth: '2025-09-01T00:00:00.000Z',
+      });
+
+      expect(mockInvoicesService.create).toHaveBeenCalledWith(
+        'user-1',
+        pdfFile,
         undefined,
       );
     });
@@ -58,12 +65,11 @@ describe('InvoicesController', () => {
     it('should forward password from body to service', async () => {
       mockInvoicesService.create.mockResolvedValue({ invoiceId: 'inv-1' });
 
-      await controller.create('user-1', pdfFile, billingMonthDto, 's3cret');
+      await controller.create('user-1', pdfFile, emptyDto, 's3cret');
 
       expect(mockInvoicesService.create).toHaveBeenCalledWith(
         'user-1',
         pdfFile,
-        new Date('2025-09-01T00:00:00.000Z'),
         's3cret',
       );
     });

--- a/apps/api/src/invoices/invoices.controller.ts
+++ b/apps/api/src/invoices/invoices.controller.ts
@@ -39,15 +39,10 @@ export class InvoicesController {
       }),
     )
     file: Express.Multer.File,
-    @Body() body: CreateInvoiceDto,
+    @Body() _body: CreateInvoiceDto,
     @Body('password') password?: string,
   ): Promise<{ invoiceId: string }> {
-    return this.invoicesService.create(
-      userId,
-      file,
-      new Date(body.billingMonth),
-      password,
-    );
+    return this.invoicesService.create(userId, file, password);
   }
 
   @Get()

--- a/apps/api/src/invoices/invoices.repository.spec.ts
+++ b/apps/api/src/invoices/invoices.repository.spec.ts
@@ -7,6 +7,7 @@ const mockPrisma = {
     create: jest.fn(),
     findFirst: jest.fn(),
     findMany: jest.fn(),
+    update: jest.fn(),
     delete: jest.fn(),
   },
 };
@@ -28,23 +29,22 @@ describe('InvoicesRepository', () => {
   });
 
   describe('create', () => {
-    it('should create an invoice with PENDING status and return it', async () => {
+    it('should create an invoice with PENDING status (billingMonth filled later by the listener) and return it', async () => {
       const invoice = {
         id: 'inv-1',
         userId: 'user-1',
         filename: 'fatura.pdf',
         storagePath: 'invoices/user-1/fatura.pdf',
         status: 'PENDING',
+        billingMonth: null,
         createdAt: new Date(),
       };
       mockPrisma.invoice.create.mockResolvedValue(invoice);
 
-      const billingMonth = new Date('2025-09-01');
       const result = await repository.create({
         userId: 'user-1',
         filename: 'fatura.pdf',
         storagePath: 'invoices/user-1/fatura.pdf',
-        billingMonth,
       });
 
       expect(result).toEqual(invoice);
@@ -53,8 +53,32 @@ describe('InvoicesRepository', () => {
           userId: 'user-1',
           filename: 'fatura.pdf',
           storagePath: 'invoices/user-1/fatura.pdf',
-          billingMonth,
         },
+      });
+    });
+  });
+
+  describe('updateStatus', () => {
+    it('should update only status when billingMonth is not provided', async () => {
+      mockPrisma.invoice.update.mockResolvedValue({});
+
+      await repository.updateStatus('inv-1', 'FAILED');
+
+      expect(mockPrisma.invoice.update).toHaveBeenCalledWith({
+        where: { id: 'inv-1' },
+        data: { status: 'FAILED' },
+      });
+    });
+
+    it('should update both status and billingMonth when both are provided', async () => {
+      mockPrisma.invoice.update.mockResolvedValue({});
+      const billingMonth = new Date('2026-04-01T00:00:00.000Z');
+
+      await repository.updateStatus('inv-1', 'DONE', billingMonth);
+
+      expect(mockPrisma.invoice.update).toHaveBeenCalledWith({
+        where: { id: 'inv-1' },
+        data: { status: 'DONE', billingMonth },
       });
     });
   });

--- a/apps/api/src/invoices/invoices.repository.ts
+++ b/apps/api/src/invoices/invoices.repository.ts
@@ -7,7 +7,6 @@ interface CreateInvoiceData {
   userId: string;
   filename: string;
   storagePath: string;
-  billingMonth: Date;
 }
 
 export type InvoiceWithTransactions = Invoice & { transactions: Transaction[] };
@@ -52,8 +51,15 @@ export class InvoicesRepository {
     });
   }
 
-  async updateStatus(id: string, status: InvoiceStatus): Promise<void> {
-    await this.prisma.invoice.update({ where: { id }, data: { status } });
+  async updateStatus(
+    id: string,
+    status: InvoiceStatus,
+    billingMonth?: Date,
+  ): Promise<void> {
+    await this.prisma.invoice.update({
+      where: { id },
+      data: billingMonth ? { status, billingMonth } : { status },
+    });
   }
 
   async deleteById(id: string, userId: string): Promise<void> {

--- a/apps/api/src/invoices/invoices.service.spec.ts
+++ b/apps/api/src/invoices/invoices.service.spec.ts
@@ -55,16 +55,15 @@ describe('InvoicesService', () => {
       service = await createService();
     });
 
-    it('should upload with user-scoped path, create invoice, emit event and return invoiceId', async () => {
+    it('should upload with user-scoped path, create invoice (no billingMonth — set later by listener), emit event and return invoiceId', async () => {
       mockStorageService.upload.mockResolvedValue('local/user-1/fatura.pdf');
       mockInvoicesRepository.create.mockResolvedValue({
         id: 'inv-1',
         userId: 'user-1',
         storagePath: 'local/user-1/fatura.pdf',
       });
-      const billingMonth = new Date('2025-09-01');
 
-      const result = await service.create('user-1', file, billingMonth);
+      const result = await service.create('user-1', file);
 
       expect(mockStorageService.upload).toHaveBeenCalledWith(
         'invoices',
@@ -76,7 +75,6 @@ describe('InvoicesService', () => {
         userId: 'user-1',
         filename: 'fatura.pdf',
         storagePath: 'local/user-1/fatura.pdf',
-        billingMonth,
       });
       expect(mockEventEmitter.emit).toHaveBeenCalledWith(
         'invoice.created',
@@ -90,9 +88,9 @@ describe('InvoicesService', () => {
         new InternalServerErrorException('upload failed'),
       );
 
-      await expect(
-        service.create('user-1', file, new Date('2025-09-01')),
-      ).rejects.toThrow(InternalServerErrorException);
+      await expect(service.create('user-1', file)).rejects.toThrow(
+        InternalServerErrorException,
+      );
       expect(mockInvoicesRepository.create).not.toHaveBeenCalled();
       expect(mockEventEmitter.emit).not.toHaveBeenCalled();
     });
@@ -101,9 +99,7 @@ describe('InvoicesService', () => {
       mockStorageService.upload.mockResolvedValue('local/user-1/fatura.pdf');
       mockInvoicesRepository.create.mockRejectedValue(new Error('db error'));
 
-      await expect(
-        service.create('user-1', file, new Date('2025-09-01')),
-      ).rejects.toThrow();
+      await expect(service.create('user-1', file)).rejects.toThrow();
       expect(mockEventEmitter.emit).not.toHaveBeenCalled();
     });
   });
@@ -123,9 +119,9 @@ describe('InvoicesService', () => {
     });
 
     it('should throw UnprocessableEntityException when no password is provided', async () => {
-      await expect(
-        service.create('user-1', encryptedFile, new Date('2025-09-01')),
-      ).rejects.toThrow(UnprocessableEntityException);
+      await expect(service.create('user-1', encryptedFile)).rejects.toThrow(
+        UnprocessableEntityException,
+      );
       expect(mockStorageService.upload).not.toHaveBeenCalled();
       expect(mockPdfDecryptionService.decrypt).not.toHaveBeenCalled();
     });
@@ -140,12 +136,7 @@ describe('InvoicesService', () => {
         storagePath: 'local/user-1/fatura.pdf',
       });
 
-      const result = await service.create(
-        'user-1',
-        encryptedFile,
-        new Date('2025-09-01'),
-        's3cret',
-      );
+      const result = await service.create('user-1', encryptedFile, 's3cret');
 
       expect(mockPdfDecryptionService.decrypt).toHaveBeenCalledWith(
         encryptedBuffer,
@@ -166,7 +157,7 @@ describe('InvoicesService', () => {
       );
 
       const err = await service
-        .create('user-1', encryptedFile, new Date('2025-09-01'), 'wrong')
+        .create('user-1', encryptedFile, 'wrong')
         .catch((e: unknown) => e);
 
       expect(err).toBeInstanceOf(UnprocessableEntityException);
@@ -185,12 +176,7 @@ describe('InvoicesService', () => {
       );
 
       await expect(
-        service.create(
-          'user-1',
-          encryptedFile,
-          new Date('2025-09-01'),
-          's3cret',
-        ),
+        service.create('user-1', encryptedFile, 's3cret'),
       ).rejects.toThrow(/qpdf/);
       expect(mockStorageService.upload).not.toHaveBeenCalled();
     });

--- a/apps/api/src/invoices/invoices.service.ts
+++ b/apps/api/src/invoices/invoices.service.ts
@@ -36,7 +36,6 @@ export class InvoicesService {
   async create(
     userId: string,
     file: Express.Multer.File,
-    billingMonth: Date,
     password?: string,
   ): Promise<{ invoiceId: string }> {
     let buffer = file.buffer;
@@ -71,7 +70,6 @@ export class InvoicesService {
       userId,
       filename: file.originalname,
       storagePath,
-      billingMonth,
     });
 
     this.eventEmitter.emit(

--- a/apps/api/src/transactions/transactions.listener.spec.ts
+++ b/apps/api/src/transactions/transactions.listener.spec.ts
@@ -61,13 +61,14 @@ describe('TransactionsListener', () => {
     jest.resetAllMocks();
   });
 
-  it('should download PDF, extract transactions, classify them, save them and mark invoice as DONE', async () => {
+  it('should download PDF, extract transactions, classify them, save them and mark invoice as DONE with billingMonth', async () => {
     mockStorageService.download.mockResolvedValue(pdfBuffer);
     mockExtractionService.extract.mockResolvedValue({
       invoiceTotal: 45.9,
       transactions: extracted,
       payments: [],
       futureInstallments: [],
+      billingMonth: '2026-04',
     });
     mockCategorizationService.classifyMany.mockResolvedValue([classified]);
 
@@ -88,10 +89,11 @@ describe('TransactionsListener', () => {
     expect(mockInvoicesRepository.updateStatus).toHaveBeenCalledWith(
       'inv-1',
       InvoiceStatus.DONE,
+      new Date('2026-04-01T00:00:00.000Z'),
     );
   });
 
-  it('should mark invoice as FAILED and not save transactions when extraction throws', async () => {
+  it('should mark invoice as FAILED (without billingMonth) when extraction throws', async () => {
     mockStorageService.download.mockResolvedValue(pdfBuffer);
     mockExtractionService.extract.mockRejectedValue(
       new Error('sum check failed'),

--- a/apps/api/src/transactions/transactions.listener.ts
+++ b/apps/api/src/transactions/transactions.listener.ts
@@ -28,7 +28,7 @@ export class TransactionsListener {
         INVOICES_BUCKET,
         event.storagePath,
       );
-      const { transactions: extracted } =
+      const { transactions: extracted, billingMonth } =
         await this.extractionService.extract(pdf);
       const classifications =
         await this.categorizationService.classifyMany(extracted);
@@ -43,6 +43,7 @@ export class TransactionsListener {
       await this.invoicesRepository.updateStatus(
         event.invoiceId,
         InvoiceStatus.DONE,
+        new Date(`${billingMonth}-01T00:00:00.000Z`),
       );
     } catch (error) {
       this.logger.error(


### PR DESCRIPTION
Closes #79

## Resumo

- O Claude agora extrai o `billingMonth` (mês de vencimento, `YYYY-MM`) direto da fatura via tool schema.
- `TransactionsListener` persiste o valor no `Invoice` ao finalizar o processamento.
- Frontend não precisa mais informar banco nem mês ao fazer upload — a v1 (#82) já pode consumir.
- Mantém compatibilidade com o MVP atual: o controller ignora `billingMonth` se o body ainda mandar.

## Mudanças

- **Prisma**: `Invoice.billingMonth` → nullable, com migration
- **ExtractionService**: novo campo no tool schema + prompt instruction + validação regex `YYYY-MM` (`01`–`12`)
- **TransactionsListener**: usa o `billingMonth` extraído ao atualizar para `DONE` (`YYYY-MM` → `Date('YYYY-MM-01T00:00:00.000Z')`)
- **InvoicesRepository.updateStatus()**: aceita `billingMonth?: Date` opcional
- **InvoicesService.create()**: signature limpa (sem `billingMonth`)
- **CreateInvoiceDto**: `billingMonth` opcional; controller passa a ignorar
- **DTOs de resposta**: `billingMonth: Date | null`

## Test plan

- [x] Unit tests verdes (`pnpm test`) — 171 passing, 0 failing
- [x] Lint e build limpos (`pnpm lint`, `pnpm build`)
- [ ] Integration tests com PDFs reais (`RUN_EXTRACTION_INTEGRATION=1 pnpm test`) — confirmar que o Claude extrai `billingMonth` correto para Itaú, Nubank e Bradesco. Roda manualmente porque consome créditos da API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)