### PR TITLE
feat: página de transações (#84)

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -4,7 +4,7 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { rawBody: true });
-  app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
   app.enableCors({
     origin:
       process.env.CORS_ORIGIN?.split(',') ??

--- a/apps/api/src/transactions/transactions.controller.ts
+++ b/apps/api/src/transactions/transactions.controller.ts
@@ -4,6 +4,7 @@ import { CurrentUser } from '../auth/current-user.decorator';
 import { BulkCategorizeDto } from './dto/bulk-categorize.dto';
 import { UpdateTransactionDto } from './dto/update-transaction.dto';
 import { TransactionsService } from './transactions.service';
+import { TransactionWithBank } from './transactions.repository';
 
 @Controller('transactions')
 export class TransactionsController {
@@ -22,7 +23,7 @@ export class TransactionsController {
     @Query('sort') sort?: 'date' | 'amount',
     @Query('order') order?: 'asc' | 'desc',
   ): Promise<{
-    data: Transaction[];
+    data: TransactionWithBank[];
     total: number;
     page: number;
     limit: number;

--- a/apps/api/src/transactions/transactions.controller.ts
+++ b/apps/api/src/transactions/transactions.controller.ts
@@ -19,6 +19,8 @@ export class TransactionsController {
     @Query('q') q?: string,
     @Query('page') page?: number,
     @Query('limit') limit?: number,
+    @Query('sort') sort?: 'date' | 'amount',
+    @Query('order') order?: 'asc' | 'desc',
   ): Promise<{
     data: Transaction[];
     total: number;
@@ -35,6 +37,8 @@ export class TransactionsController {
       q,
       page: resolvedPage,
       limit: resolvedLimit,
+      sort,
+      order,
     });
     return { data, total, page: resolvedPage, limit: resolvedLimit };
   }

--- a/apps/api/src/transactions/transactions.repository.ts
+++ b/apps/api/src/transactions/transactions.repository.ts
@@ -2,6 +2,10 @@ import { Injectable } from '@nestjs/common';
 import { Prisma, Transaction, TransactionType } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 
+export type TransactionWithBank = Transaction & {
+  invoice: { bank: string | null };
+};
+
 export interface FindPaginatedFilters {
   month?: string;
   bank?: string;
@@ -78,7 +82,7 @@ export class TransactionsRepository {
   async findPaginated(
     userId: string,
     filters: FindPaginatedFilters,
-  ): Promise<{ data: Transaction[]; total: number }> {
+  ): Promise<{ data: TransactionWithBank[]; total: number }> {
     const invoiceWhere: Record<string, unknown> = { userId };
     if (filters.month) {
       const start = new Date(`${filters.month}-01T00:00:00.000Z`);
@@ -107,6 +111,7 @@ export class TransactionsRepository {
         skip,
         take: filters.limit,
         orderBy: { [sortField]: sortOrder },
+        include: { invoice: { select: { bank: true } } },
       }),
       this.prisma.transaction.count({ where }),
     ]);

--- a/apps/api/src/transactions/transactions.repository.ts
+++ b/apps/api/src/transactions/transactions.repository.ts
@@ -10,6 +10,8 @@ export interface FindPaginatedFilters {
   q?: string;
   page: number;
   limit: number;
+  sort?: 'date' | 'amount';
+  order?: 'asc' | 'desc';
 }
 
 export interface TransactionCreateData {
@@ -96,13 +98,15 @@ export class TransactionsRepository {
       ];
     }
 
+    const sortField = filters.sort ?? 'date';
+    const sortOrder = filters.order ?? 'desc';
     const skip = (filters.page - 1) * filters.limit;
     const [data, total] = await Promise.all([
       this.prisma.transaction.findMany({
         where,
         skip,
         take: filters.limit,
-        orderBy: { date: 'desc' },
+        orderBy: { [sortField]: sortOrder },
       }),
       this.prisma.transaction.count({ where }),
     ]);

--- a/apps/api/src/transactions/transactions.service.spec.ts
+++ b/apps/api/src/transactions/transactions.service.spec.ts
@@ -197,6 +197,47 @@ describe('TransactionsService', () => {
         expect.objectContaining({ page: 1, limit: 20 }),
       );
     });
+
+    it('forwards sort: date and order: asc to the repository', async () => {
+      mockTransactionsRepository.findPaginated.mockResolvedValue({
+        data: [],
+        total: 0,
+      });
+
+      await service.findMany('user-1', { page: 1, limit: 15, sort: 'date', order: 'asc' });
+
+      expect(mockTransactionsRepository.findPaginated).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({ sort: 'date', order: 'asc' }),
+      );
+    });
+
+    it('forwards sort: amount and order: desc to the repository', async () => {
+      mockTransactionsRepository.findPaginated.mockResolvedValue({
+        data: [],
+        total: 0,
+      });
+
+      await service.findMany('user-1', { page: 1, limit: 15, sort: 'amount', order: 'desc' });
+
+      expect(mockTransactionsRepository.findPaginated).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({ sort: 'amount', order: 'desc' }),
+      );
+    });
+
+    it('omits sort and order when not provided', async () => {
+      mockTransactionsRepository.findPaginated.mockResolvedValue({
+        data: [],
+        total: 0,
+      });
+
+      await service.findMany('user-1', { page: 1, limit: 20 });
+
+      const call = (mockTransactionsRepository.findPaginated.mock.calls as unknown[][])[0][1] as Record<string, unknown>;
+      expect(call.sort).toBeUndefined();
+      expect(call.order).toBeUndefined();
+    });
   });
 
   describe('countByDescription', () => {

--- a/apps/api/src/transactions/transactions.service.ts
+++ b/apps/api/src/transactions/transactions.service.ts
@@ -4,7 +4,7 @@ import { MerchantRulesRepository } from '../merchant-rules/merchant-rules.reposi
 import { PrismaService } from '../prisma/prisma.service';
 import { BulkCategorizeDto } from './dto/bulk-categorize.dto';
 import { UpdateTransactionDto } from './dto/update-transaction.dto';
-import { TransactionsRepository } from './transactions.repository';
+import { TransactionsRepository, TransactionWithBank } from './transactions.repository';
 
 export interface FindManyFilters {
   month?: string;
@@ -29,7 +29,7 @@ export class TransactionsService {
   async findMany(
     userId: string,
     filters: FindManyFilters,
-  ): Promise<{ data: Transaction[]; total: number }> {
+  ): Promise<{ data: TransactionWithBank[]; total: number }> {
     return this.transactionsRepository.findPaginated(userId, {
       ...filters,
       page: filters.page ?? 1,

--- a/apps/api/src/transactions/transactions.service.ts
+++ b/apps/api/src/transactions/transactions.service.ts
@@ -14,6 +14,8 @@ export interface FindManyFilters {
   q?: string;
   page?: number;
   limit?: number;
+  sort?: 'date' | 'amount';
+  order?: 'asc' | 'desc';
 }
 
 @Injectable()

--- a/apps/web/app/(v1)/dashboard/components/monthly-bar-chart.tsx
+++ b/apps/web/app/(v1)/dashboard/components/monthly-bar-chart.tsx
@@ -26,7 +26,7 @@ export function MonthlyBarChart({ data, selectedBanks }: MonthlyBarChartProps) {
   });
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex-1 flex flex-col min-h-0">
       <div className="flex items-center gap-4 mb-3">
         {selectedBanks.map((bank) => (
           <span key={bank} className="flex items-center gap-1.5 text-xs text-slate-500">
@@ -35,8 +35,8 @@ export function MonthlyBarChart({ data, selectedBanks }: MonthlyBarChartProps) {
           </span>
         ))}
       </div>
-      <div className="flex-1">
-        <ResponsiveContainer width="100%" height={200}>
+      <div className="flex-1 min-h-[200px]">
+        <ResponsiveContainer width="100%" height="100%">
           <BarChart data={chartData} barSize={20} barCategoryGap="30%">
             <XAxis dataKey="month" tick={{ fontSize: 11, fill: '#94a3b8' }} axisLine={false} tickLine={false} />
             <YAxis tickFormatter={formatK} tick={{ fontSize: 11, fill: '#94a3b8' }} axisLine={false} tickLine={false} width={44} />

--- a/apps/web/app/(v1)/dashboard/dashboard-client.tsx
+++ b/apps/web/app/(v1)/dashboard/dashboard-client.tsx
@@ -86,7 +86,7 @@ export function DashboardClient({
 
         {/* Charts */}
         <div className="grid grid-cols-1 md:grid-cols-5 gap-4 mb-4">
-          <div className="md:col-span-3 bg-white rounded-2xl border border-slate-200 p-5 flex flex-col">
+          <div className="md:col-span-3 bg-white rounded-2xl border border-slate-200 p-5 flex flex-col min-w-0">
             <p className="text-[10px] font-semibold text-slate-400 uppercase tracking-widest mb-3">
               Histórico — últimos 6 meses
             </p>

--- a/apps/web/app/(v1)/dashboard/loading.tsx
+++ b/apps/web/app/(v1)/dashboard/loading.tsx
@@ -1,0 +1,56 @@
+function Bone({ className }: { className: string }) {
+  return <div className={`bg-slate-200 rounded-lg animate-pulse ${className}`} />;
+}
+
+export default function DashboardLoading() {
+  return (
+    <div className="flex">
+      {/* Sidebar skeleton — lg only, fixed */}
+      <aside
+        className="w-48 flex-shrink-0 bg-white border-r border-slate-200 fixed left-0 bottom-0 py-5 px-3 hidden lg:flex flex-col gap-1"
+        style={{ top: 'calc(3.5rem + 2.75rem)' }}
+      >
+        <Bone className="h-3 w-12 mb-3" />
+        {[...Array(5)].map((_, i) => <Bone key={i} className="h-8 w-full" />)}
+        <Bone className="h-3 w-16 mt-4 mb-3" />
+        {[...Array(3)].map((_, i) => <Bone key={i} className="h-8 w-full" />)}
+      </aside>
+
+      {/* Main content */}
+      <div className="flex-1 lg:ml-48 p-5 lg:p-7 min-w-0">
+        {/* Header */}
+        <div className="mb-6">
+          <Bone className="h-3 w-24 mb-2" />
+          <Bone className="h-10 w-48" />
+        </div>
+
+        {/* Charts */}
+        <div className="grid grid-cols-1 md:grid-cols-5 gap-4 mb-4">
+          <div className="md:col-span-3 bg-white rounded-2xl border border-slate-200 p-5 min-w-0">
+            <Bone className="h-3 w-40 mb-4" />
+            <Bone className="h-[200px] w-full rounded-xl" />
+          </div>
+          <div className="md:col-span-2 bg-white rounded-2xl border border-slate-200 p-5">
+            <Bone className="h-3 w-32 mb-4" />
+            <Bone className="h-[180px] w-full rounded-full mx-auto max-w-[180px]" />
+            <div className="mt-4 grid grid-cols-2 gap-2">
+              {[...Array(6)].map((_, i) => <Bone key={i} className="h-4 w-full" />)}
+            </div>
+          </div>
+        </div>
+
+        {/* Invoice cards */}
+        <Bone className="h-3 w-32 mb-3" />
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="bg-white rounded-2xl border border-slate-200 border-l-4 border-l-slate-200 p-5">
+              <Bone className="h-3 w-24 mb-1" />
+              <Bone className="h-3 w-16 mb-6" />
+              <Bone className="h-7 w-32" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(v1)/faturas/loading.tsx
+++ b/apps/web/app/(v1)/faturas/loading.tsx
@@ -1,0 +1,40 @@
+function Bone({ className }: { className: string }) {
+  return <div className={`bg-slate-200 rounded-lg animate-pulse ${className}`} />;
+}
+
+export default function FaturasLoading() {
+  return (
+    <div className="max-w-3xl mx-auto p-5 lg:p-7">
+      {/* Upload zone */}
+      <div className="bg-white rounded-2xl border border-slate-200 p-6 mb-6">
+        <div className="border-2 border-dashed border-slate-200 rounded-xl p-10 flex flex-col items-center gap-3">
+          <Bone className="h-12 w-12 rounded-xl" />
+          <Bone className="h-4 w-40" />
+          <Bone className="h-3 w-56" />
+        </div>
+      </div>
+
+      {/* Section label */}
+      <Bone className="h-3 w-36 mb-3" />
+
+      {/* Invoice list */}
+      <div className="space-y-3">
+        {[...Array(3)].map((_, i) => (
+          <div key={i} className="bg-white rounded-2xl border border-slate-200 border-l-4 border-l-slate-200 p-5">
+            <div className="flex items-start justify-between">
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-3 mb-3">
+                  <Bone className="h-4 w-24" />
+                  <Bone className="h-5 w-16 rounded-full" />
+                </div>
+                <Bone className="h-7 w-32 mb-2" />
+                <Bone className="h-3 w-20" />
+              </div>
+              <Bone className="h-4 w-4 flex-shrink-0 ml-3" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(v1)/nav.tsx
+++ b/apps/web/app/(v1)/nav.tsx
@@ -5,6 +5,7 @@ import { usePathname } from 'next/navigation';
 
 const NAV_ITEMS = [
   { label: 'Dashboard', href: '/dashboard' },
+  { label: 'Transações', href: '/transacoes' },
   { label: 'Faturas', href: '/faturas' },
 ];
 

--- a/apps/web/app/(v1)/transacoes/loading.tsx
+++ b/apps/web/app/(v1)/transacoes/loading.tsx
@@ -1,0 +1,53 @@
+function Bone({ className }: { className: string }) {
+  return <div className={`bg-slate-200 rounded-lg animate-pulse ${className}`} />;
+}
+
+export default function TransacoesLoading() {
+  return (
+    <div className="p-5 lg:p-7">
+      {/* Filter bar */}
+      <div className="flex flex-wrap items-center gap-3 mb-5">
+        <Bone className="h-9 flex-1 min-w-48" />
+        <Bone className="h-9 w-36" />
+        <Bone className="h-9 w-32" />
+        <Bone className="h-9 w-40" />
+      </div>
+
+      {/* Table */}
+      <div className="bg-white rounded-2xl border border-slate-200 overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center gap-4 px-5 py-3.5 border-b border-slate-100">
+          <Bone className="h-3 w-10" />
+          <Bone className="h-3 w-32 flex-1" />
+          <Bone className="h-3 w-20" />
+          <Bone className="h-3 w-16 hidden lg:block" />
+          <Bone className="h-3 w-14 ml-auto" />
+        </div>
+
+        {/* Rows */}
+        {[...Array(10)].map((_, i) => (
+          <div key={i} className="flex items-center gap-4 px-5 py-3.5 border-b border-slate-50 last:border-0">
+            <Bone className="h-4 w-16 flex-shrink-0" />
+            <div className="flex-1 min-w-0">
+              <Bone className="h-4 w-48 mb-1.5" />
+              <Bone className={`h-3 w-32 ${i % 3 === 0 ? 'block' : 'hidden'}`} />
+            </div>
+            <Bone className="h-4 w-24 flex-shrink-0" />
+            <Bone className="h-4 w-16 hidden lg:block flex-shrink-0" />
+            <Bone className="h-4 w-20 ml-auto flex-shrink-0" />
+          </div>
+        ))}
+
+        {/* Pagination */}
+        <div className="flex items-center justify-between px-5 py-3.5 border-t border-slate-100 bg-slate-50/50">
+          <Bone className="h-3 w-32" />
+          <div className="flex items-center gap-2">
+            <Bone className="h-7 w-20" />
+            <Bone className="h-3 w-10" />
+            <Bone className="h-7 w-20" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(v1)/transacoes/page.tsx
+++ b/apps/web/app/(v1)/transacoes/page.tsx
@@ -1,0 +1,31 @@
+import { auth } from '@clerk/nextjs/server';
+import { redirect } from 'next/navigation';
+import { TransactionsClient } from './transactions-client';
+
+const API = process.env.NEXT_PUBLIC_API_URL;
+
+async function fetchBillingMonths(token: string): Promise<string[]> {
+  const res = await fetch(`${API}/invoices`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: 'no-store',
+  });
+  if (!res.ok) return [];
+  const invoices = (await res.json()) as { billingMonth: string | null }[];
+  const seen = new Set<string>();
+  for (const inv of invoices) {
+    if (!inv.billingMonth) continue;
+    const d = new Date(inv.billingMonth);
+    seen.add(`${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`);
+  }
+  return [...seen].sort().reverse();
+}
+
+export default async function TransacoesPage() {
+  const { getToken } = await auth();
+  const token = await getToken();
+  if (!token) redirect('/sign-in');
+
+  const months = await fetchBillingMonths(token);
+
+  return <TransactionsClient months={months} />;
+}

--- a/apps/web/app/(v1)/transacoes/transactions-client.tsx
+++ b/apps/web/app/(v1)/transacoes/transactions-client.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import { useTransactions, LIMIT } from '../../../hooks/use-transactions';
+import { formatBRL, formatMonth } from '../../../lib/format';
+import { bankLabel, BANK_DISPLAY } from '../../../lib/banks';
+
+const CATEGORIES = [
+  'Alimentação', 'Transporte', 'Moradia', 'Saúde',
+  'Entretenimento', 'Assinaturas', 'Compras', 'Educação',
+  'Viagem', 'Finanças', 'Pets', 'Outros',
+];
+
+const SELECT_CLS = 'bg-white border border-slate-200 rounded-lg px-3 h-9 text-sm text-slate-700 outline-none cursor-pointer';
+
+interface ApiTransaction {
+  id: string;
+  date: string;
+  description: string;
+  alias: string | null;
+  amount: string | number;
+  type: 'DEBIT' | 'CREDIT';
+  category: string | null;
+  subcategory: string | null;
+  invoice: { bank: string | null };
+}
+
+function SortTh({
+  label, field, sort, order, onClick, align = 'left',
+}: {
+  label: string;
+  field: 'date' | 'amount';
+  sort: 'date' | 'amount';
+  order: 'asc' | 'desc';
+  onClick: () => void;
+  align?: 'left' | 'right';
+}) {
+  const active = sort === field;
+  const icon = !active ? '↕' : order === 'asc' ? '↑' : '↓';
+  return (
+    <th
+      onClick={onClick}
+      className={`text-${align} text-xs font-semibold text-slate-400 uppercase tracking-widest px-5 py-3.5 cursor-pointer select-none hover:text-slate-600 transition-colors`}
+    >
+      {align === 'right' && (
+        <span className={active ? 'text-indigo-500' : 'text-slate-300'}>{icon} </span>
+      )}
+      {label}
+      {align === 'left' && (
+        <span className={`ml-1 ${active ? 'text-indigo-500' : 'text-slate-300'}`}>{icon}</span>
+      )}
+    </th>
+  );
+}
+
+export function TransactionsClient({ months }: { months: string[] }) {
+  const {
+    transactions, total, page, sort, order,
+    q, month, bank, category, loading,
+    setPage, setQ, setMonth, setBank, setCategory, toggleSort,
+  } = useTransactions();
+
+  const txs = transactions as ApiTransaction[];
+  const totalPages = Math.max(1, Math.ceil(total / LIMIT));
+
+  return (
+    <div className="p-5 lg:p-7">
+      <div className="flex flex-wrap items-center gap-3 mb-5">
+        <div className="flex items-center gap-2 bg-white border border-slate-200 rounded-lg px-3 h-9 flex-1 min-w-48">
+          <svg className="w-4 h-4 text-slate-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+          <input
+            type="text"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Buscar transação…"
+            className="text-sm text-slate-800 w-full outline-none placeholder-slate-400"
+          />
+        </div>
+
+        <select value={month} onChange={(e) => setMonth(e.target.value)} className={SELECT_CLS}>
+          <option value="">Todos os meses</option>
+          {months.map((m) => (
+            <option key={m} value={m}>{formatMonth(m)}</option>
+          ))}
+        </select>
+
+        <select value={bank} onChange={(e) => setBank(e.target.value)} className={SELECT_CLS}>
+          <option value="">Todos os bancos</option>
+          {Object.entries(BANK_DISPLAY)
+            .filter(([k]) => k !== 'other')
+            .map(([key, label]) => (
+              <option key={key} value={key}>{label}</option>
+            ))}
+        </select>
+
+        <select value={category} onChange={(e) => setCategory(e.target.value)} className={SELECT_CLS}>
+          <option value="">Todas as categorias</option>
+          {CATEGORIES.map((c) => (
+            <option key={c} value={c}>{c}</option>
+          ))}
+        </select>
+      </div>
+
+      <div className="bg-white rounded-2xl border border-slate-200 overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-100">
+                <SortTh label="Data" field="date" sort={sort} order={order} onClick={() => toggleSort('date')} />
+                <th className="text-left text-xs font-semibold text-slate-400 uppercase tracking-widest px-4 py-3.5">
+                  Descrição
+                </th>
+                <th className="text-left text-xs font-semibold text-slate-400 uppercase tracking-widest px-4 py-3.5 whitespace-nowrap">
+                  Categoria
+                </th>
+                <th className="text-left text-xs font-semibold text-slate-400 uppercase tracking-widest px-4 py-3.5 hidden lg:table-cell">
+                  Banco
+                </th>
+                <SortTh label="Valor" field="amount" sort={sort} order={order} onClick={() => toggleSort('amount')} align="right" />
+              </tr>
+            </thead>
+            <tbody className={loading ? 'opacity-50 pointer-events-none' : ''}>
+              {txs.length === 0 && !loading ? (
+                <tr>
+                  <td colSpan={5} className="text-center text-sm text-slate-400 py-12">
+                    Nenhuma transação encontrada
+                  </td>
+                </tr>
+              ) : (
+                txs.map((tx) => (
+                  <tr key={tx.id} className="border-b border-slate-50 last:border-0 hover:bg-slate-50/60 transition-colors">
+                    <td className="px-5 py-3.5 text-sm text-slate-500 whitespace-nowrap font-mono tabular-nums">
+                      {new Date(tx.date).toLocaleDateString('pt-BR')}
+                    </td>
+                    <td className="px-4 py-3.5 max-w-xs">
+                      <span className="text-slate-800 truncate block">{tx.alias ?? tx.description}</span>
+                      {tx.alias && (
+                        <span className="text-xs text-slate-400 truncate block mt-0.5">{tx.description}</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3.5 whitespace-nowrap">
+                      {tx.category ? (
+                        <span className="text-slate-600">
+                          {tx.category}
+                          {tx.subcategory && (
+                            <span className="text-slate-400 hidden md:inline"> / {tx.subcategory}</span>
+                          )}
+                        </span>
+                      ) : (
+                        <span className="text-slate-300">—</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3.5 hidden lg:table-cell text-slate-500">
+                      {bankLabel(tx.invoice?.bank ?? null)}
+                    </td>
+                    <td className="px-5 py-3.5 text-right whitespace-nowrap font-mono tabular-nums">
+                      <span className={tx.type === 'CREDIT' ? 'text-emerald-600 font-medium' : 'text-slate-800'}>
+                        {tx.type === 'CREDIT' ? '+' : ''}{formatBRL(Number(tx.amount))}
+                      </span>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-3 px-5 py-3.5 border-t border-slate-100 bg-slate-50/50">
+          <p className="text-xs text-slate-400 whitespace-nowrap">
+            {total} transações · página {page} de {totalPages}
+          </p>
+          <div className="flex items-center gap-1">
+            <button
+              onClick={() => setPage(page - 1)}
+              disabled={page <= 1}
+              className="px-3 py-1.5 text-xs text-slate-600 hover:bg-slate-100 rounded-lg transition-colors disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap"
+            >
+              ← Anterior
+            </button>
+            <span className="text-xs text-slate-500 px-2 whitespace-nowrap tabular-nums">{page} / {totalPages}</span>
+            <button
+              onClick={() => setPage(page + 1)}
+              disabled={page >= totalPages}
+              className="px-3 py-1.5 text-xs text-slate-600 hover:bg-slate-100 rounded-lg transition-colors disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap"
+            >
+              Próxima →
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/hooks/use-transactions.spec.ts
+++ b/apps/web/hooks/use-transactions.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react';
+import { useTransactions } from './use-transactions';
+
+jest.mock('@clerk/nextjs', () => ({
+  useAuth: jest.fn(),
+}));
+
+import { useAuth } from '@clerk/nextjs';
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+
+function makeResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    ok: true,
+    json: async () => ({ data: [], total: 0, page: 1, limit: 15, ...overrides }),
+  };
+}
+
+describe('useTransactions', () => {
+  const mockGetToken = jest.fn().mockResolvedValue('token-abc');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue({ getToken: mockGetToken } as ReturnType<typeof useAuth>);
+    global.fetch = jest.fn().mockResolvedValue(makeResponse());
+    process.env.NEXT_PUBLIC_API_URL = 'http://api.test';
+  });
+
+  async function settle() {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it('fetches /transactions with page=1, limit=15, sort=date, order=desc on mount', async () => {
+    renderHook(() => useTransactions());
+    await settle();
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const url = new URL((global.fetch as jest.Mock).mock.calls[0][0] as string);
+    expect(url.pathname).toContain('/transactions');
+    expect(url.searchParams.get('page')).toBe('1');
+    expect(url.searchParams.get('limit')).toBe('15');
+    expect(url.searchParams.get('sort')).toBe('date');
+    expect(url.searchParams.get('order')).toBe('desc');
+    expect((global.fetch as jest.Mock).mock.calls[0][1].headers.Authorization).toBe('Bearer token-abc');
+  });
+
+  it('resets page to 1 when month filter changes', async () => {
+    const { result } = renderHook(() => useTransactions());
+    await settle();
+
+    act(() => { result.current.setPage(3); });
+    expect(result.current.page).toBe(3);
+
+    act(() => { result.current.setMonth('2026-04'); });
+    expect(result.current.page).toBe(1);
+  });
+
+  it('resets page to 1 when bank filter changes', async () => {
+    const { result } = renderHook(() => useTransactions());
+    await settle();
+
+    act(() => { result.current.setPage(2); });
+    act(() => { result.current.setBank('nubank'); });
+    expect(result.current.page).toBe(1);
+  });
+
+  it('resets page to 1 when q changes', async () => {
+    const { result } = renderHook(() => useTransactions());
+    await settle();
+
+    act(() => { result.current.setPage(2); });
+    act(() => { result.current.setQ('uber'); });
+    expect(result.current.page).toBe(1);
+  });
+
+  it('toggleSort: same column toggles desc → asc → desc', async () => {
+    const { result } = renderHook(() => useTransactions());
+    await settle();
+
+    expect(result.current.sort).toBe('date');
+    expect(result.current.order).toBe('desc');
+
+    act(() => { result.current.toggleSort('date'); });
+    expect(result.current.sort).toBe('date');
+    expect(result.current.order).toBe('asc');
+
+    act(() => { result.current.toggleSort('date'); });
+    expect(result.current.order).toBe('desc');
+  });
+
+  it('toggleSort: different column resets order to desc', async () => {
+    const { result } = renderHook(() => useTransactions());
+    await settle();
+
+    act(() => { result.current.toggleSort('amount'); });
+    expect(result.current.sort).toBe('amount');
+    expect(result.current.order).toBe('desc');
+  });
+
+  it('setCategory clears subcategory and resets page', async () => {
+    const { result } = renderHook(() => useTransactions());
+    await settle();
+
+    act(() => { result.current.setSubcategory('Delivery'); });
+    act(() => { result.current.setPage(2); });
+    expect(result.current.subcategory).toBe('Delivery');
+
+    act(() => { result.current.setCategory('Transporte'); });
+    expect(result.current.subcategory).toBe('');
+    expect(result.current.page).toBe(1);
+  });
+
+  it('setPage changes to the requested page without resetting filters', async () => {
+    const { result } = renderHook(() => useTransactions());
+    await settle();
+
+    act(() => { result.current.setMonth('2026-05'); });
+    act(() => { result.current.setPage(3); });
+
+    expect(result.current.page).toBe(3);
+    expect(result.current.month).toBe('2026-05');
+  });
+
+  it('debounces search query — fetch is not called immediately on input', async () => {
+    jest.useFakeTimers({ legacyFakeTimers: true });
+    try {
+      const { result } = renderHook(() => useTransactions());
+      await act(async () => { jest.runAllImmediates(); });
+
+      const callsBefore = (global.fetch as jest.Mock).mock.calls.length;
+
+      act(() => { result.current.setQ('netflix'); });
+      expect((global.fetch as jest.Mock).mock.calls.length).toBe(callsBefore);
+
+      await act(async () => { jest.advanceTimersByTime(350); });
+      expect((global.fetch as jest.Mock).mock.calls.length).toBeGreaterThan(callsBefore);
+
+      const lastUrl = (global.fetch as jest.Mock).mock.calls.at(-1)[0] as string;
+      expect(lastUrl).toContain('q=netflix');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/apps/web/hooks/use-transactions.ts
+++ b/apps/web/hooks/use-transactions.ts
@@ -1,0 +1,146 @@
+'use client';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { useAuth } from '@clerk/nextjs';
+
+export const LIMIT = 15;
+const DEBOUNCE_MS = 300;
+
+export interface TransactionsState {
+  transactions: unknown[];
+  total: number;
+  page: number;
+  sort: 'date' | 'amount';
+  order: 'asc' | 'desc';
+  q: string;
+  month: string;
+  bank: string;
+  category: string;
+  subcategory: string;
+  loading: boolean;
+  setPage: (page: number) => void;
+  setQ: (q: string) => void;
+  setMonth: (month: string) => void;
+  setBank: (bank: string) => void;
+  setCategory: (category: string) => void;
+  setSubcategory: (subcategory: string) => void;
+  toggleSort: (field: 'date' | 'amount') => void;
+}
+
+export function useTransactions(): TransactionsState {
+  const { getToken } = useAuth();
+
+  const [page, setPageState] = useState(1);
+  const [sort, setSort] = useState<'date' | 'amount'>('date');
+  const [order, setOrder] = useState<'asc' | 'desc'>('desc');
+  const [q, setQState] = useState('');
+  const [debouncedQ, setDebouncedQ] = useState('');
+  const [month, setMonthState] = useState('');
+  const [bank, setBankState] = useState('');
+  const [category, setCategoryState] = useState('');
+  const [subcategory, setSubcategoryState] = useState('');
+  const [transactions, setTransactions] = useState<unknown[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+
+  const getTokenRef = useRef(getToken);
+  getTokenRef.current = getToken;
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedQ(q), DEBOUNCE_MS);
+    return () => clearTimeout(id);
+  }, [q]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetch_() {
+      setLoading(true);
+      try {
+        const token = await getTokenRef.current();
+        const url = new URL(`${process.env.NEXT_PUBLIC_API_URL}/transactions`);
+        url.searchParams.set('page', String(page));
+        url.searchParams.set('limit', String(LIMIT));
+        url.searchParams.set('sort', sort);
+        url.searchParams.set('order', order);
+        if (debouncedQ) url.searchParams.set('q', debouncedQ);
+        if (month) url.searchParams.set('month', month);
+        if (bank) url.searchParams.set('bank', bank);
+        if (category) url.searchParams.set('category', category);
+        if (subcategory) url.searchParams.set('subcategory', subcategory);
+
+        const res = await fetch(url.toString(), {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok) return;
+        const json = await res.json() as { data: unknown[]; total: number };
+        if (!cancelled) {
+          setTransactions(json.data);
+          setTotal(json.total);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    void fetch_();
+    return () => { cancelled = true; };
+  }, [page, sort, order, debouncedQ, month, bank, category, subcategory]);
+
+  const setPage = useCallback((p: number) => setPageState(p), []);
+
+  const setQ = useCallback((v: string) => {
+    setQState(v);
+    setPageState(1);
+  }, []);
+
+  const setMonth = useCallback((v: string) => {
+    setMonthState(v);
+    setPageState(1);
+  }, []);
+
+  const setBank = useCallback((v: string) => {
+    setBankState(v);
+    setPageState(1);
+  }, []);
+
+  const setCategory = useCallback((v: string) => {
+    setCategoryState(v);
+    setSubcategoryState('');
+    setPageState(1);
+  }, []);
+
+  const setSubcategory = useCallback((v: string) => setSubcategoryState(v), []);
+
+  const toggleSort = useCallback((field: 'date' | 'amount') => {
+    setSort((prev) => {
+      if (prev === field) {
+        setOrder((o) => (o === 'desc' ? 'asc' : 'desc'));
+        return prev;
+      }
+      setOrder('desc');
+      return field;
+    });
+    setPageState(1);
+  }, []);
+
+  return {
+    transactions,
+    total,
+    page,
+    sort,
+    order,
+    q,
+    month,
+    bank,
+    category,
+    subcategory,
+    loading,
+    setPage,
+    setQ,
+    setMonth,
+    setBank,
+    setCategory,
+    setSubcategory,
+    toggleSort,
+  };
+}


### PR DESCRIPTION
Closes #84

## Summary

- **Página `/transacoes`** com tabela paginada (15 por página), filtros por mês/banco/categoria, busca debounced (300ms), sort por data e valor, e meses derivados das faturas importadas (não hardcoded).
- **Skeletons de loading** (`loading.tsx`) para dashboard, transações e faturas — replicam o layout real com `animate-pulse` e respeitam os breakpoints responsivos.
- **Fix do gráfico de barras**: usava `height={200}` fixo dentro de um grid que esticava o card, deixando espaço em branco. Agora `flex-1 + min-h-0` + `height="100%"` faz o gráfico preencher o card naturalmente.
- **Backend**: include `invoice.bank` na resposta de `/transactions` (necessário para a coluna Banco) e `transform: true` no `ValidationPipe` global (corrige 500 porque `page`/`limit` chegavam como string e o Prisma rejeitava `take: "15"`).
- **Nav**: adicionado item "Transações" entre Dashboard e Faturas.

## Test plan

- [x] Carregar `/transacoes` — primeira página com 15 transações ordenadas por data desc
- [x] Filtrar por mês — só meses com fatura importada aparecem no select; resultados filtram
- [x] Filtrar por banco e categoria — combinam com os outros filtros
- [x] Digitar na busca — não dispara fetch imediato; após ~300ms refaz a query
- [x] Clicar nos headers Data e Valor — alterna asc/desc; trocar coluna reseta para desc
- [x] Paginação — botões Anterior/Próxima desabilitam nos limites; contador `página X de Y` atualiza
- [ ] Mobile — coluna Categoria visível (subcategoria escondida em telas <md); banco escondido em telas <lg
- [x] Recarregar dashboard, transações e faturas — skeleton aparece antes do conteúdo
- [x] Dashboard — bar chart preenche o card mesmo quando a legenda do pie chart cresce

🤖 Generated with [Claude Code](https://claude.com/claude-code)