### PR TITLE
fix: descontar créditos do total exibido (#94)

### DIFF
--- a/apps/api/src/invoices/invoices-query.service.spec.ts
+++ b/apps/api/src/invoices/invoices-query.service.spec.ts
@@ -7,6 +7,7 @@ const mockInvoicesRepository = {
   findAllWithFilters: jest.fn(),
   findHistory: jest.fn(),
   findSummaryByMonth: jest.fn(),
+  findCreditsSumByMonth: jest.fn(),
 };
 
 describe('InvoicesQueryService', () => {
@@ -91,6 +92,76 @@ describe('InvoicesQueryService', () => {
         invoiceTotal: null,
         transactionCount: 0,
       });
+    });
+
+    it('falls back to net (debits − credits) when invoiceTotal is null', async () => {
+      mockInvoicesRepository.findAllWithFilters.mockResolvedValue([
+        {
+          id: 'inv-3',
+          filename: 'legacy.pdf',
+          status: 'DONE',
+          bank: 'itau',
+          billingMonth: new Date('2026-05-01T00:00:00.000Z'),
+          invoiceTotal: null,
+          createdAt: new Date('2026-05-20T00:00:00.000Z'),
+          _count: { transactions: 3 },
+          transactions: [
+            { amount: new Decimal('100.00'), type: 'DEBIT' },
+            { amount: new Decimal('50.00'), type: 'DEBIT' },
+            { amount: new Decimal('30.00'), type: 'CREDIT' },
+          ],
+        },
+      ]);
+
+      const result = await service.list('user-1', {});
+
+      expect(result[0].total).toBeCloseTo(120, 2);
+    });
+
+    it('invoiceTotal has priority over the computed net when both exist', async () => {
+      mockInvoicesRepository.findAllWithFilters.mockResolvedValue([
+        {
+          id: 'inv-4',
+          filename: 'recent.pdf',
+          status: 'DONE',
+          bank: 'itau',
+          billingMonth: new Date('2026-05-01T00:00:00.000Z'),
+          invoiceTotal: new Decimal('999.99'),
+          createdAt: new Date('2026-05-20T00:00:00.000Z'),
+          _count: { transactions: 2 },
+          transactions: [
+            { amount: new Decimal('100.00'), type: 'DEBIT' },
+            { amount: new Decimal('30.00'), type: 'CREDIT' },
+          ],
+        },
+      ]);
+
+      const result = await service.list('user-1', {});
+
+      expect(result[0].total).toBeCloseTo(999.99, 2);
+    });
+
+    it('fallback returns debit sum when there are no credits', async () => {
+      mockInvoicesRepository.findAllWithFilters.mockResolvedValue([
+        {
+          id: 'inv-5',
+          filename: 'old.pdf',
+          status: 'DONE',
+          bank: 'nubank',
+          billingMonth: new Date('2026-04-01T00:00:00.000Z'),
+          invoiceTotal: null,
+          createdAt: new Date('2026-04-20T00:00:00.000Z'),
+          _count: { transactions: 2 },
+          transactions: [
+            { amount: new Decimal('80.00'), type: 'DEBIT' },
+            { amount: new Decimal('20.00'), type: 'DEBIT' },
+          ],
+        },
+      ]);
+
+      const result = await service.list('user-1', {});
+
+      expect(result[0].total).toBeCloseTo(100, 2);
     });
   });
 
@@ -275,6 +346,43 @@ describe('InvoicesQueryService', () => {
 
       expect(typeof result.byCategory[0].amount).toBe('number');
       expect(result.byCategory[0].amount).toBeCloseTo(1080.5, 2);
+    });
+
+    it('subtracts the credits sum from total when there are refunds', async () => {
+      mockInvoicesRepository.findSummaryByMonth.mockResolvedValue([
+        {
+          category: 'Alimentação',
+          subcategory: 'Delivery',
+          _sum: { amount: new Decimal('500.00') },
+        },
+        {
+          category: 'Transporte',
+          subcategory: null,
+          _sum: { amount: new Decimal('200.00') },
+        },
+      ]);
+      mockInvoicesRepository.findCreditsSumByMonth.mockResolvedValue(
+        new Decimal('80.00'),
+      );
+
+      const result = await service.summary('user-1', '2026-05');
+
+      expect(result.total).toBeCloseTo(620, 2);
+    });
+
+    it('does not change total when findCreditsSumByMonth returns null', async () => {
+      mockInvoicesRepository.findSummaryByMonth.mockResolvedValue([
+        {
+          category: 'Alimentação',
+          subcategory: null,
+          _sum: { amount: new Decimal('300.00') },
+        },
+      ]);
+      mockInvoicesRepository.findCreditsSumByMonth.mockResolvedValue(null);
+
+      const result = await service.summary('user-1', '2026-05');
+
+      expect(result.total).toBeCloseTo(300, 2);
     });
   });
 });

--- a/apps/api/src/invoices/invoices-query.service.ts
+++ b/apps/api/src/invoices/invoices-query.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { TransactionType } from '@prisma/client';
 import { InvoicesRepository } from './invoices.repository';
 
 export interface InvoiceListItemDto {
@@ -43,10 +44,15 @@ export class InvoicesQueryService {
       const invoiceTotal = inv.invoiceTotal
         ? inv.invoiceTotal.toNumber()
         : null;
-      const transactionSum = inv.transactions.reduce(
-        (sum, t) => sum + t.amount.toNumber(),
-        0,
-      );
+      // invoiceTotal is null for invoices processed before the field was added; fall back to net (debits − credits)
+      const total =
+        invoiceTotal ??
+        inv.transactions.reduce((sum, t) => {
+          const value = t.amount.toNumber();
+          return t.type === TransactionType.CREDIT
+            ? sum - value
+            : sum + value;
+        }, 0);
       return {
         id: inv.id,
         filename: inv.filename,
@@ -54,8 +60,7 @@ export class InvoicesQueryService {
         bank: inv.bank ?? null,
         billingMonth: inv.billingMonth,
         invoiceTotal,
-        // invoiceTotal is null for invoices processed before the field was added; fall back to DEBIT sum
-        total: invoiceTotal ?? transactionSum,
+        total,
         transactionCount: inv._count.transactions,
         createdAt: inv.createdAt,
       };
@@ -80,10 +85,10 @@ export class InvoicesQueryService {
   }
 
   async summary(userId: string, month: string): Promise<SummaryDto> {
-    const groups = await this.invoicesRepository.findSummaryByMonth(
-      userId,
-      month,
-    );
+    const [groups, creditsSum] = await Promise.all([
+      this.invoicesRepository.findSummaryByMonth(userId, month),
+      this.invoicesRepository.findCreditsSumByMonth(userId, month),
+    ]);
 
     const byCategory = groups
       .map((g) => ({
@@ -93,7 +98,9 @@ export class InvoicesQueryService {
       }))
       .sort((a, b) => b.amount - a.amount);
 
-    const total = byCategory.reduce((sum, c) => sum + c.amount, 0);
+    const credits = creditsSum?.toNumber() ?? 0;
+    const total =
+      byCategory.reduce((sum, c) => sum + c.amount, 0) - credits;
     return { total, byCategory };
   }
 }

--- a/apps/api/src/invoices/invoices.repository.ts
+++ b/apps/api/src/invoices/invoices.repository.ts
@@ -1,6 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { Decimal } from '@prisma/client/runtime/library';
-import { Invoice, InvoiceStatus, Transaction } from '@prisma/client';
+import {
+  Invoice,
+  InvoiceStatus,
+  Transaction,
+  TransactionType,
+} from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 
 interface CreateInvoiceData {
@@ -25,7 +30,8 @@ export type InvoiceWithTransactions = Invoice & { transactions: Transaction[] };
 export type InvoiceWithDebits = Invoice & {
   transactions: { amount: Decimal }[];
 };
-export type InvoiceWithCount = InvoiceWithDebits & {
+export type InvoiceWithCount = Invoice & {
+  transactions: { amount: Decimal; type: TransactionType }[];
   _count: { transactions: number };
 };
 export type InvoiceHistoryRow = {
@@ -109,7 +115,7 @@ export class InvoicesRepository {
       orderBy: { createdAt: 'desc' },
       include: {
         _count: { select: { transactions: true } },
-        transactions: { where: { type: 'DEBIT' }, select: { amount: true } },
+        transactions: { select: { amount: true, type: true } },
       },
     }) as Promise<InvoiceWithCount[]>;
   }
@@ -156,6 +162,28 @@ export class InvoicesRepository {
       where: { invoiceId: { in: ids }, type: 'DEBIT' },
       _sum: { amount: true },
     }) as unknown as Promise<CategoryGroupRow[]>;
+  }
+
+  async findCreditsSumByMonth(
+    userId: string,
+    month: string,
+  ): Promise<Decimal | null> {
+    const start = new Date(`${month}-01T00:00:00.000Z`);
+    const end = new Date(start);
+    end.setUTCMonth(end.getUTCMonth() + 1);
+
+    const result = await this.prisma.transaction.aggregate({
+      where: {
+        type: TransactionType.CREDIT,
+        invoice: {
+          userId,
+          status: InvoiceStatus.DONE,
+          billingMonth: { gte: start, lt: end },
+        },
+      },
+      _sum: { amount: true },
+    });
+    return result._sum.amount;
   }
 
   async deleteById(id: string, userId: string): Promise<void> {


### PR DESCRIPTION
Closes #94

## Summary

- **`GET /invoices/summary`**: agora subtrai a soma dos créditos do `total`. O `byCategory` continua com apenas débitos (categorias de gasto). Afeta o `grandTotal` do dashboard.
- **`GET /invoices`**: fallback para faturas sem `invoiceTotal` agora calcula net (débitos − créditos) em vez de só somar débitos. Afeta a lista de faturas e os cards do dashboard.
- **Repository**: novo `findCreditsSumByMonth` usa `transaction.aggregate` com relation filter (1 query). `findAllWithFilters` agora seleciona `amount` + `type` no include (sem filtro de DEBIT).

## Fora do escopo

- `mvp/dashboard.tsx` (dashboard antigo, vai sair)
- `InvoiceWithDebits` / `findAllByUserIdWithDebits` / `InvoiceResponseDto` — dead code, sem consumer; remoção em PR separado de limpeza.

## Test plan

- [ ] Subir uma fatura com pelo menos 1 reembolso (CREDIT). Verificar:
  - [ ] `GET /invoices/summary?month=YYYY-MM` retorna `total = soma(débitos) - soma(créditos)`
  - [ ] `byCategory` não inclui categoria de reembolso (só as de gasto)
  - [ ] Dashboard exibe `grandTotal` descontado
- [ ] Lista de faturas (`/faturas`) — totais conferem com a fatura física (já desconta crédito via `invoiceTotal`)
- [ ] Faturas antigas sem `invoiceTotal` (legacy): card mostra net das transações

🤖 Generated with [Claude Code](https://claude.com/claude-code)